### PR TITLE
feat: editor tabbed layout + optimization tools

### DIFF
--- a/Editor/Yes2SDKKtx2Tool.cs
+++ b/Editor/Yes2SDKKtx2Tool.cs
@@ -1,0 +1,471 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+using Debug = UnityEngine.Debug;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// KTX2 texture compression tool. Batch-converts project textures to KTX2
+    /// format using the toktx CLI from Khronos KTX-Software.
+    /// </summary>
+    public static class Yes2SDKKtx2Tool
+    {
+        public enum Ktx2Preset
+        {
+            UASTC_Zstd,
+            ETC1S
+        }
+
+        [Serializable]
+        public class Settings
+        {
+            public Ktx2Preset preset = Ktx2Preset.UASTC_Zstd;
+            public int uastcQuality = 2;          // 0-4
+            public int zstdLevel = 3;             // 1-22
+            public int etc1sQuality = 128;        // 1-255
+            public int etc1sCompressionLevel = 2; // 0-5
+            public bool generateMipmaps = false;
+        }
+
+        public class ConversionResult
+        {
+            public string sourceAssetPath;
+            public string outputPath;
+            public long originalSize;
+            public long ktx2Size;
+            public float compressionRatio;
+            public bool success;
+            public string errorMessage;
+        }
+
+        private const string KTX_PACKAGE_ID = "com.unity.cloud.ktx";
+        private const string TOKTX_PATH_PREF = "Yes2SDK_ToktxPath";
+        private const string KTX_SOFTWARE_RELEASES_URL = "https://github.com/KhronosGroup/KTX-Software/releases";
+
+        public static string KtxSoftwareReleasesUrl => KTX_SOFTWARE_RELEASES_URL;
+
+        // --- Package Detection ---
+
+        /// <summary>
+        /// Check if com.unity.cloud.ktx is installed.
+        /// </summary>
+        public static bool IsKtxPackageInstalled()
+        {
+            var listRequest = Client.List(true);
+            while (!listRequest.IsCompleted) { }
+
+            if (listRequest.Status == StatusCode.Success)
+            {
+                return listRequest.Result.Any(p =>
+                    p.name == KTX_PACKAGE_ID ||
+                    p.name == "com.atteneder.ktx");
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Install com.unity.cloud.ktx via Package Manager.
+        /// </summary>
+        public static void InstallKtxPackage()
+        {
+            Debug.Log($"[Yes2SDK] Installing {KTX_PACKAGE_ID}...");
+            Client.Add(KTX_PACKAGE_ID);
+        }
+
+        // --- toktx Detection ---
+
+        /// <summary>
+        /// Find the toktx executable. Checks EditorPrefs, PATH, and platform-specific locations.
+        /// Returns the path if found, null otherwise.
+        /// </summary>
+        public static string FindToktx()
+        {
+            // 1. Check saved path
+            var saved = EditorPrefs.GetString(TOKTX_PATH_PREF, "");
+            if (!string.IsNullOrEmpty(saved) && File.Exists(saved))
+            {
+                if (ValidateToktx(saved) != null)
+                    return saved;
+            }
+
+            // 2. Check PATH
+            var inPath = FindInPath("toktx");
+            if (inPath != null && ValidateToktx(inPath) != null)
+            {
+                SaveToktxPath(inPath);
+                return inPath;
+            }
+
+            // 3. Platform-specific locations
+            string[] candidates;
+            if (Application.platform == RuntimePlatform.OSXEditor)
+            {
+                candidates = new[]
+                {
+                    "/usr/local/bin/toktx",
+                    "/opt/homebrew/bin/toktx",
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".local/bin/toktx")
+                };
+            }
+            else if (Application.platform == RuntimePlatform.WindowsEditor)
+            {
+                var programFiles = Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles);
+                candidates = new[]
+                {
+                    Path.Combine(programFiles, "KTX-Software", "bin", "toktx.exe"),
+                    Path.Combine(programFiles + " (x86)", "KTX-Software", "bin", "toktx.exe")
+                };
+            }
+            else
+            {
+                candidates = new[]
+                {
+                    "/usr/local/bin/toktx",
+                    "/usr/bin/toktx"
+                };
+            }
+
+            foreach (var path in candidates)
+            {
+                if (File.Exists(path) && ValidateToktx(path) != null)
+                {
+                    SaveToktxPath(path);
+                    return path;
+                }
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Validate toktx by running --version. Returns version string or null.
+        /// </summary>
+        public static string ValidateToktx(string toktxPath)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = toktxPath,
+                    Arguments = "--version",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process == null) return null;
+
+                var output = process.StandardOutput.ReadToEnd();
+                var error = process.StandardError.ReadToEnd();
+                process.WaitForExit(5000);
+
+                var version = !string.IsNullOrEmpty(output) ? output.Trim() : error.Trim();
+                return !string.IsNullOrEmpty(version) ? version : null;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        public static void SaveToktxPath(string path)
+        {
+            EditorPrefs.SetString(TOKTX_PATH_PREF, path);
+        }
+
+        // --- Conversion ---
+
+        /// <summary>
+        /// Convert a single texture to KTX2.
+        /// </summary>
+        public static ConversionResult ConvertTexture(string assetPath, Settings settings, string toktxPath)
+        {
+            var result = new ConversionResult
+            {
+                sourceAssetPath = assetPath
+            };
+
+            try
+            {
+                if (string.IsNullOrEmpty(toktxPath))
+                {
+                    result.success = false;
+                    result.errorMessage = "toktx path is not set.";
+                    return result;
+                }
+
+                // Determine source file path
+                var fullSourcePath = Path.GetFullPath(assetPath);
+                var extension = Path.GetExtension(fullSourcePath).ToLowerInvariant();
+                string inputPath = fullSourcePath;
+                string tempFile = null;
+
+                // If not PNG or JPG, export to temp PNG
+                if (extension != ".png" && extension != ".jpg" && extension != ".jpeg")
+                {
+                    tempFile = ExportToTempPng(assetPath);
+                    if (tempFile == null)
+                    {
+                        result.success = false;
+                        result.errorMessage = $"Failed to export {assetPath} to PNG for conversion.";
+                        return result;
+                    }
+                    inputPath = tempFile;
+                }
+
+                result.originalSize = new FileInfo(inputPath).Length;
+
+                // Determine output path
+                var relativePath = assetPath;
+                if (relativePath.StartsWith("Assets/"))
+                    relativePath = relativePath.Substring("Assets/".Length);
+
+                var ktx2RelativePath = Path.ChangeExtension(relativePath, ".ktx2");
+                var outputDir = Path.Combine(Application.streamingAssetsPath, "ktx2");
+                var outputFullPath = Path.Combine(outputDir, ktx2RelativePath);
+                result.outputPath = $"ktx2/{ktx2RelativePath}";
+
+                // Ensure output directory exists
+                var outputFileDir = Path.GetDirectoryName(outputFullPath);
+                if (!Directory.Exists(outputFileDir))
+                    Directory.CreateDirectory(outputFileDir);
+
+                // Build toktx arguments
+                var args = BuildToktxArgs(inputPath, outputFullPath, settings);
+
+                Debug.Log($"[Yes2SDK] KTX2 cmd: \"{toktxPath}\" {args}");
+
+                // Run toktx
+                var psi = new ProcessStartInfo
+                {
+                    FileName = toktxPath,
+                    Arguments = args,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                    CreateNoWindow = true
+                };
+
+                Process process;
+                try
+                {
+                    process = Process.Start(psi);
+                }
+                catch (Exception ex)
+                {
+                    result.success = false;
+                    result.errorMessage = $"Failed to start toktx at \"{toktxPath}\": {ex.Message}";
+                    return result;
+                }
+
+                if (process == null)
+                {
+                    result.success = false;
+                    result.errorMessage = $"Process.Start returned null for \"{toktxPath}\".";
+                    return result;
+                }
+
+                var stderr = process.StandardError.ReadToEnd();
+                process.WaitForExit(30000);
+
+                var exitCode = process.ExitCode;
+                process.Dispose();
+
+                if (exitCode != 0)
+                {
+                    result.success = false;
+                    result.errorMessage = $"toktx exited with code {exitCode}: {stderr}";
+                    return result;
+                }
+
+                // Clean up temp file
+                if (tempFile != null && File.Exists(tempFile))
+                    File.Delete(tempFile);
+
+                if (!File.Exists(outputFullPath))
+                {
+                    result.success = false;
+                    result.errorMessage = "toktx did not produce an output file.";
+                    return result;
+                }
+
+                result.ktx2Size = new FileInfo(outputFullPath).Length;
+                result.compressionRatio = result.originalSize > 0
+                    ? (float)result.originalSize / result.ktx2Size
+                    : 0;
+                result.success = true;
+            }
+            catch (Exception e)
+            {
+                result.success = false;
+                result.errorMessage = e.Message;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Batch convert textures. Shows a cancelable progress bar.
+        /// </summary>
+        public static List<ConversionResult> BatchConvert(string[] assetPaths, Settings settings, string toktxPath)
+        {
+            if (string.IsNullOrEmpty(toktxPath))
+            {
+                Debug.LogError("[Yes2SDK] KTX2: toktx path is not set. Please locate toktx in Yes2SDK > Settings > Utilities.");
+                return new List<ConversionResult>();
+            }
+
+            var results = new List<ConversionResult>();
+
+            for (int i = 0; i < assetPaths.Length; i++)
+            {
+                var path = assetPaths[i];
+                var canceled = EditorUtility.DisplayCancelableProgressBar(
+                    "Converting to KTX2",
+                    $"Processing {Path.GetFileName(path)}... ({i + 1}/{assetPaths.Length})",
+                    (float)i / assetPaths.Length);
+
+                if (canceled)
+                {
+                    Debug.Log($"[Yes2SDK] KTX2 conversion canceled after {i} of {assetPaths.Length} textures.");
+                    break;
+                }
+
+                var result = ConvertTexture(path, settings, toktxPath);
+                results.Add(result);
+
+                if (result.success)
+                {
+                    Debug.Log($"[Yes2SDK] KTX2: {path} -> {result.outputPath} ({result.compressionRatio:F1}x)");
+                }
+                else
+                {
+                    Debug.LogWarning($"[Yes2SDK] KTX2 failed: {path}: {result.errorMessage}");
+                }
+            }
+
+            EditorUtility.ClearProgressBar();
+            AssetDatabase.Refresh();
+
+            return results;
+        }
+
+        /// <summary>
+        /// Find all texture assets in a folder.
+        /// </summary>
+        public static string[] FindTexturesInFolder(string folder)
+        {
+            if (!AssetDatabase.IsValidFolder(folder))
+                return Array.Empty<string>();
+
+            var guids = AssetDatabase.FindAssets("t:Texture2D", new[] { folder });
+            return guids
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(p => !p.EndsWith(".ktx2") && !p.EndsWith(".basis"))
+                .ToArray();
+        }
+
+        // --- Private Helpers ---
+
+        private static string BuildToktxArgs(string inputPath, string outputPath, Settings settings)
+        {
+            var args = "--t2 --nowarn --assign_oetf srgb ";
+
+            if (settings.preset == Ktx2Preset.UASTC_Zstd)
+            {
+                args += $"--encode uastc --uastc_quality {settings.uastcQuality} --zcmp {settings.zstdLevel} ";
+            }
+            else
+            {
+                args += $"--encode etc1s --clevel {settings.etc1sCompressionLevel} --qlevel {settings.etc1sQuality} ";
+            }
+
+            if (settings.generateMipmaps)
+                args += "--genmipmap ";
+
+            args += $"\"{outputPath}\" \"{inputPath}\"";
+            return args;
+        }
+
+        private static string FindInPath(string executable)
+        {
+            try
+            {
+                var shell = Application.platform == RuntimePlatform.WindowsEditor ? "where" : "which";
+                var psi = new ProcessStartInfo
+                {
+                    FileName = shell,
+                    Arguments = executable,
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    CreateNoWindow = true
+                };
+
+                using var process = Process.Start(psi);
+                if (process == null) return null;
+
+                var output = process.StandardOutput.ReadToEnd().Trim();
+                process.WaitForExit(5000);
+
+                if (process.ExitCode == 0 && !string.IsNullOrEmpty(output))
+                {
+                    // Take the first line (which might have multiple results)
+                    var firstLine = output.Split('\n')[0].Trim();
+                    return File.Exists(firstLine) ? firstLine : null;
+                }
+            }
+            catch { }
+
+            return null;
+        }
+
+        private static string ExportToTempPng(string assetPath)
+        {
+            try
+            {
+                var importer = AssetImporter.GetAtPath(assetPath) as TextureImporter;
+                if (importer == null) return null;
+
+                // Temporarily make texture readable
+                bool wasReadable = importer.isReadable;
+                if (!wasReadable)
+                {
+                    importer.isReadable = true;
+                    importer.SaveAndReimport();
+                }
+
+                var texture = AssetDatabase.LoadAssetAtPath<Texture2D>(assetPath);
+                if (texture == null) return null;
+
+                var png = texture.EncodeToPNG();
+
+                // Restore readable state
+                if (!wasReadable)
+                {
+                    importer.isReadable = false;
+                    importer.SaveAndReimport();
+                }
+
+                if (png == null) return null;
+
+                var tempPath = Path.Combine(Path.GetTempPath(), $"yes2sdk_ktx2_{Guid.NewGuid()}.png");
+                File.WriteAllBytes(tempPath, png);
+                return tempPath;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[Yes2SDK] Failed to export texture to PNG: {e.Message}");
+                return null;
+            }
+        }
+    }
+}

--- a/Editor/Yes2SDKKtx2Tool.cs.meta
+++ b/Editor/Yes2SDKKtx2Tool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80c0ec1dadc9b4bc2871bdacbc80cb3b

--- a/Editor/Yes2SDKSpriteAtlasTool.cs
+++ b/Editor/Yes2SDKSpriteAtlasTool.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.U2D;
+using UnityEngine;
+using UnityEngine.U2D;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// Sprite Atlas automation tool. Scans for loose sprites and creates
+    /// WebGL-optimized SpriteAtlas assets grouped by folder.
+    /// </summary>
+    public static class Yes2SDKSpriteAtlasTool
+    {
+        [Serializable]
+        public class Settings
+        {
+            public int padding = 4;
+            public int maxTextureSize = 2048;
+            public bool enableTightPacking = true;
+            public bool enableRotation = false;
+            public bool generateMipMaps = false;
+            public bool sRGB = true;
+            public int compressionQuality = 50;
+        }
+
+        public class AtlasReport
+        {
+            public string atlasName;
+            public string folderPath;
+            public string outputPath;
+            public int spriteCount;
+            public bool alreadyExisted;
+            public bool created;
+        }
+
+        public class ScanResult
+        {
+            public string folderPath;
+            public string folderName;
+            public List<string> spritePaths = new List<string>();
+        }
+
+        /// <summary>
+        /// Scan source folders for sprites not already packed in any SpriteAtlas.
+        /// Returns results grouped by parent folder.
+        /// </summary>
+        public static List<ScanResult> ScanForLooseSprites(string[] sourceFolders)
+        {
+            // Find all existing atlas packable paths for quick lookup
+            var packedPaths = GetAllPackedPaths();
+
+            var results = new Dictionary<string, ScanResult>();
+
+            foreach (var folder in sourceFolders)
+            {
+                if (!AssetDatabase.IsValidFolder(folder))
+                {
+                    Debug.LogWarning($"[Yes2SDK] Sprite Atlas: Folder not found: {folder}. Skipped.");
+                    continue;
+                }
+
+                var guids = AssetDatabase.FindAssets("t:Sprite", new[] { folder });
+
+                foreach (var guid in guids)
+                {
+                    var path = AssetDatabase.GUIDToAssetPath(guid);
+
+                    // Skip if already packed
+                    if (IsPathCoveredByAtlas(path, packedPaths))
+                        continue;
+
+                    // Group by immediate parent folder
+                    var parentFolder = Path.GetDirectoryName(path).Replace('\\', '/');
+                    if (!results.TryGetValue(parentFolder, out var result))
+                    {
+                        result = new ScanResult
+                        {
+                            folderPath = parentFolder,
+                            folderName = Path.GetFileName(parentFolder)
+                        };
+                        results[parentFolder] = result;
+                    }
+
+                    if (!result.spritePaths.Contains(path))
+                        result.spritePaths.Add(path);
+                }
+            }
+
+            return results.Values.OrderBy(r => r.folderPath).ToList();
+        }
+
+        /// <summary>
+        /// Create atlases for the given scan results.
+        /// </summary>
+        public static List<AtlasReport> CreateAtlases(List<ScanResult> scanResults, Settings settings, string outputDirectory)
+        {
+            var reports = new List<AtlasReport>();
+
+            // Ensure output directory exists
+            if (!AssetDatabase.IsValidFolder(outputDirectory))
+            {
+                CreateFolderRecursive(outputDirectory);
+            }
+
+            for (int i = 0; i < scanResults.Count; i++)
+            {
+                var scan = scanResults[i];
+                EditorUtility.DisplayProgressBar(
+                    "Creating Sprite Atlases",
+                    $"Processing {scan.folderName}... ({i + 1}/{scanResults.Count})",
+                    (float)i / scanResults.Count);
+
+                var report = CreateAtlasForFolder(scan, settings, outputDirectory);
+                reports.Add(report);
+            }
+
+            EditorUtility.ClearProgressBar();
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+
+            return reports;
+        }
+
+        /// <summary>
+        /// Run full automation: scan + create + report.
+        /// </summary>
+        public static (List<ScanResult> scan, List<AtlasReport> reports) RunAutomation(
+            string[] sourceFolders, Settings settings, string outputDirectory)
+        {
+            var scanResults = ScanForLooseSprites(sourceFolders);
+
+            if (scanResults.Count == 0)
+                return (scanResults, new List<AtlasReport>());
+
+            var reports = CreateAtlases(scanResults, settings, outputDirectory);
+            return (scanResults, reports);
+        }
+
+        private static AtlasReport CreateAtlasForFolder(ScanResult scan, Settings settings, string outputDirectory)
+        {
+            var atlasName = $"Atlas_{SanitizeName(scan.folderName)}";
+            var outputPath = $"{outputDirectory}/{atlasName}.spriteatlas";
+
+            var report = new AtlasReport
+            {
+                atlasName = atlasName,
+                folderPath = scan.folderPath,
+                outputPath = outputPath,
+                spriteCount = scan.spritePaths.Count
+            };
+
+            // Check if atlas already exists
+            var existing = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(outputPath);
+            if (existing != null)
+            {
+                report.alreadyExisted = true;
+
+                // Update the existing atlas: add the folder as a packable
+                var folder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(scan.folderPath);
+                if (folder != null)
+                {
+                    existing.Remove(existing.GetPackables());
+                    existing.Add(new UnityEngine.Object[] { folder });
+                    ApplySettings(existing, settings);
+                    EditorUtility.SetDirty(existing);
+                }
+
+                report.created = true;
+                Debug.Log($"[Yes2SDK] Updated existing atlas: {atlasName} ({scan.spritePaths.Count} sprites from {scan.folderPath})");
+                return report;
+            }
+
+            // Create new atlas
+            var atlas = new SpriteAtlas();
+            ApplySettings(atlas, settings);
+
+            // Add the folder as a packable (Unity will include all sprites in it)
+            var folderAsset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(scan.folderPath);
+            if (folderAsset != null)
+            {
+                atlas.Add(new UnityEngine.Object[] { folderAsset });
+            }
+            else
+            {
+                // Fallback: add individual sprites
+                var sprites = scan.spritePaths
+                    .Select(p => AssetDatabase.LoadAssetAtPath<UnityEngine.Object>(p))
+                    .Where(o => o != null)
+                    .ToArray();
+                atlas.Add(sprites);
+            }
+
+            AssetDatabase.CreateAsset(atlas, outputPath);
+            report.created = true;
+
+            Debug.Log($"[Yes2SDK] Created atlas: {atlasName} ({scan.spritePaths.Count} sprites from {scan.folderPath})");
+            return report;
+        }
+
+        private static void ApplySettings(SpriteAtlas atlas, Settings settings)
+        {
+            atlas.SetPackingSettings(new SpriteAtlasPackingSettings
+            {
+                padding = settings.padding,
+                enableTightPacking = settings.enableTightPacking,
+                enableRotation = settings.enableRotation,
+                blockOffset = 1
+            });
+
+            atlas.SetTextureSettings(new SpriteAtlasTextureSettings
+            {
+                generateMipMaps = settings.generateMipMaps,
+                sRGB = settings.sRGB,
+                filterMode = FilterMode.Bilinear,
+                readable = false
+            });
+
+            // WebGL platform override
+            var webgl = atlas.GetPlatformSettings("WebGL");
+            webgl.overridden = true;
+            webgl.maxTextureSize = settings.maxTextureSize;
+            webgl.format = TextureImporterFormat.ETC2_RGBA8Crunched;
+            webgl.compressionQuality = settings.compressionQuality;
+            atlas.SetPlatformSettings(webgl);
+        }
+
+        /// <summary>
+        /// Get all paths that are covered by existing sprite atlases (folders and individual assets).
+        /// </summary>
+        private static HashSet<string> GetAllPackedPaths()
+        {
+            var paths = new HashSet<string>();
+            var atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas");
+
+            foreach (var guid in atlasGuids)
+            {
+                var atlasPath = AssetDatabase.GUIDToAssetPath(guid);
+                var atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+                if (atlas == null) continue;
+
+                var packables = atlas.GetPackables();
+                foreach (var packable in packables)
+                {
+                    if (packable == null) continue;
+                    var path = AssetDatabase.GetAssetPath(packable);
+                    if (!string.IsNullOrEmpty(path))
+                        paths.Add(path);
+                }
+            }
+
+            return paths;
+        }
+
+        /// <summary>
+        /// Check if a sprite path is covered by an atlas (either directly or via a packed folder).
+        /// </summary>
+        private static bool IsPathCoveredByAtlas(string spritePath, HashSet<string> packedPaths)
+        {
+            // Direct match
+            if (packedPaths.Contains(spritePath))
+                return true;
+
+            // Check if any packed folder is a parent of this sprite
+            foreach (var packedPath in packedPaths)
+            {
+                if (spritePath.StartsWith(packedPath + "/"))
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static string SanitizeName(string name)
+        {
+            var chars = name.ToCharArray();
+            for (int i = 0; i < chars.Length; i++)
+            {
+                if (!char.IsLetterOrDigit(chars[i]) && chars[i] != '_')
+                    chars[i] = '_';
+            }
+            return new string(chars);
+        }
+
+        private static void CreateFolderRecursive(string path)
+        {
+            var parts = path.Split('/');
+            var current = parts[0]; // "Assets"
+
+            for (int i = 1; i < parts.Length; i++)
+            {
+                var next = current + "/" + parts[i];
+                if (!AssetDatabase.IsValidFolder(next))
+                {
+                    AssetDatabase.CreateFolder(current, parts[i]);
+                }
+                current = next;
+            }
+        }
+    }
+}

--- a/Editor/Yes2SDKSpriteAtlasTool.cs.meta
+++ b/Editor/Yes2SDKSpriteAtlasTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a8462798f89e144d3853bb2f48ed4bd7

--- a/Editor/Yes2SDKTextureSwapTool.cs
+++ b/Editor/Yes2SDKTextureSwapTool.cs
@@ -1,0 +1,495 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using UnityEditor.U2D;
+using UnityEngine.U2D;
+using UnityEngine.UI;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// Scans scenes and prefabs for texture references that have KTX2 versions
+    /// in StreamingAssets, and swaps them to use Yes2SDKKtx2Image at runtime.
+    /// Uses reflection to access Yes2SDKKtx2Image (lives in optional Yes2SDK.Ktx2 assembly).
+    /// </summary>
+    public static class Yes2SDKTextureSwapTool
+    {
+        public enum ScanScope
+        {
+            ActiveScene,
+            AllBuildScenes,
+            PrefabsInFolder
+        }
+
+        public class SwapCandidate
+        {
+            public string assetPath;
+            public string gameObjectPath;
+            public string componentType;
+            public string originalTexturePath;
+            public string ktx2Path;
+            public bool ktx2Exists;
+            public bool inAtlas;
+        }
+
+        public class SwapReport
+        {
+            public int swapped;
+            public int skippedMissingKtx2;
+            public int skippedInAtlas;
+            public int skippedAlreadySwapped;
+        }
+
+        private const string KTX2_IMAGE_TYPE = "Yes2SDK.Yes2SDKKtx2Image, Yes2SDK.Ktx2";
+        // Note: KTX package assembly is "Ktx" (not "KtxUnity"), namespace is "KtxUnity"
+
+        private static Type _ktx2ImageType;
+        private static PropertyInfo _ktx2PathProperty;
+
+        /// <summary>
+        /// Returns the Yes2SDKKtx2Image type if available (com.unity.cloud.ktx installed), null otherwise.
+        /// </summary>
+        public static Type GetKtx2ImageType()
+        {
+            if (_ktx2ImageType == null)
+                _ktx2ImageType = Type.GetType(KTX2_IMAGE_TYPE);
+            return _ktx2ImageType;
+        }
+
+        /// <summary>
+        /// Whether the KTX2 runtime loader component is available.
+        /// </summary>
+        public static bool IsKtx2ImageAvailable => GetKtx2ImageType() != null;
+
+        // --- Scanning ---
+
+        /// <summary>
+        /// Scan the currently active scene for swap candidates.
+        /// </summary>
+        public static List<SwapCandidate> ScanActiveScene()
+        {
+            var scene = SceneManager.GetActiveScene();
+            return ScanScene(scene);
+        }
+
+        /// <summary>
+        /// Scan all scenes in Build Settings for swap candidates.
+        /// </summary>
+        public static List<SwapCandidate> ScanAllBuildScenes()
+        {
+            var candidates = new List<SwapCandidate>();
+            var buildScenes = EditorBuildSettings.scenes;
+
+            // Save current scene
+            var currentScene = SceneManager.GetActiveScene().path;
+
+            for (int i = 0; i < buildScenes.Length; i++)
+            {
+                var scenePath = buildScenes[i].path;
+                if (string.IsNullOrEmpty(scenePath)) continue;
+
+                EditorUtility.DisplayProgressBar("Scanning Scenes",
+                    $"Scanning {Path.GetFileName(scenePath)}... ({i + 1}/{buildScenes.Length})",
+                    (float)i / buildScenes.Length);
+
+                var scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Single);
+                candidates.AddRange(ScanScene(scene));
+            }
+
+            // Reopen original scene
+            if (!string.IsNullOrEmpty(currentScene))
+                EditorSceneManager.OpenScene(currentScene, OpenSceneMode.Single);
+
+            EditorUtility.ClearProgressBar();
+            return candidates;
+        }
+
+        /// <summary>
+        /// Scan a single scene for swap candidates.
+        /// </summary>
+        public static List<SwapCandidate> ScanScene(Scene scene)
+        {
+            var candidates = new List<SwapCandidate>();
+            var rootObjects = scene.GetRootGameObjects();
+
+            foreach (var root in rootObjects)
+            {
+                ScanGameObjectRecursive(root, scene.path, candidates);
+            }
+
+            return candidates;
+        }
+
+        /// <summary>
+        /// Scan prefabs in a folder for swap candidates.
+        /// </summary>
+        public static List<SwapCandidate> ScanPrefabs(string folder)
+        {
+            var candidates = new List<SwapCandidate>();
+
+            if (!AssetDatabase.IsValidFolder(folder))
+            {
+                Debug.LogWarning($"[Yes2SDK] Invalid folder: {folder}");
+                return candidates;
+            }
+
+            var guids = AssetDatabase.FindAssets("t:Prefab", new[] { folder });
+
+            for (int i = 0; i < guids.Length; i++)
+            {
+                var prefabPath = AssetDatabase.GUIDToAssetPath(guids[i]);
+
+                EditorUtility.DisplayProgressBar("Scanning Prefabs",
+                    $"Scanning {Path.GetFileName(prefabPath)}... ({i + 1}/{guids.Length})",
+                    (float)i / guids.Length);
+
+                // Skip prefab variants — only modify base prefabs
+                var prefabType = PrefabUtility.GetPrefabAssetType(
+                    AssetDatabase.LoadAssetAtPath<GameObject>(prefabPath));
+                if (prefabType == PrefabAssetType.Variant)
+                    continue;
+
+                var prefabRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+                if (prefabRoot == null) continue;
+
+                ScanGameObjectRecursive(prefabRoot, prefabPath, candidates);
+                PrefabUtility.UnloadPrefabContents(prefabRoot);
+            }
+
+            EditorUtility.ClearProgressBar();
+            return candidates;
+        }
+
+        private static void ScanGameObjectRecursive(GameObject go, string assetPath,
+            List<SwapCandidate> candidates)
+        {
+            // Skip if already has KTX2 loader (via reflection)
+            var ktx2Type = GetKtx2ImageType();
+            if (ktx2Type != null && go.GetComponent(ktx2Type) != null)
+                return;
+
+            // Check for texture-holding components
+            // Prioritize RawImage over Image if both exist (unusual but possible)
+            var rawImage = go.GetComponent<RawImage>();
+            var image = go.GetComponent<Image>();
+            var spriteRenderer = go.GetComponent<SpriteRenderer>();
+
+            if (rawImage != null && rawImage.texture != null)
+            {
+                var candidate = CreateCandidate(rawImage.texture, null, "RawImage", go, assetPath);
+                if (candidate != null)
+                    candidates.Add(candidate);
+            }
+            else if (image != null && image.sprite != null)
+            {
+                var texture = image.sprite.texture;
+                var candidate = CreateCandidate(texture, image.sprite, "Image", go, assetPath);
+                if (candidate != null)
+                    candidates.Add(candidate);
+            }
+            else if (spriteRenderer != null && spriteRenderer.sprite != null)
+            {
+                var texture = spriteRenderer.sprite.texture;
+                var candidate = CreateCandidate(texture, spriteRenderer.sprite, "SpriteRenderer", go, assetPath);
+                if (candidate != null)
+                    candidates.Add(candidate);
+            }
+
+            // Recurse into children
+            for (int i = 0; i < go.transform.childCount; i++)
+            {
+                ScanGameObjectRecursive(go.transform.GetChild(i).gameObject, assetPath, candidates);
+            }
+        }
+
+        private static SwapCandidate CreateCandidate(Texture texture, Sprite sprite,
+            string componentType, GameObject go, string assetPath)
+        {
+            var texturePath = AssetDatabase.GetAssetPath(texture);
+            if (string.IsNullOrEmpty(texturePath))
+                return null;
+
+            // Skip built-in Unity textures
+            if (texturePath.StartsWith("Resources/") || texturePath.StartsWith("Library/"))
+                return null;
+
+            // Check if sprite is part of a SpriteAtlas
+            bool inAtlas = false;
+            if (sprite != null)
+            {
+                inAtlas = IsSpriteInAtlas(texturePath);
+            }
+
+            // Compute expected KTX2 path: strip "Assets/" prefix, change extension, prepend "ktx2/"
+            var relativePath = texturePath;
+            if (relativePath.StartsWith("Assets/"))
+                relativePath = relativePath.Substring("Assets/".Length);
+
+            var ktx2RelPath = "ktx2/" + Path.ChangeExtension(relativePath, ".ktx2");
+
+            // Check if KTX2 file exists
+            var ktx2FullPath = Path.Combine(Application.streamingAssetsPath, ktx2RelPath);
+            bool ktx2Exists = File.Exists(ktx2FullPath);
+
+            return new SwapCandidate
+            {
+                assetPath = assetPath,
+                gameObjectPath = GetHierarchyPath(go),
+                componentType = componentType,
+                originalTexturePath = texturePath,
+                ktx2Path = ktx2RelPath,
+                ktx2Exists = ktx2Exists,
+                inAtlas = inAtlas
+            };
+        }
+
+        private static bool IsSpriteInAtlas(string texturePath)
+        {
+            // Find all SpriteAtlas assets and check if any pack this texture
+            var atlasGuids = AssetDatabase.FindAssets("t:SpriteAtlas");
+            foreach (var guid in atlasGuids)
+            {
+                var atlasPath = AssetDatabase.GUIDToAssetPath(guid);
+                var atlas = AssetDatabase.LoadAssetAtPath<SpriteAtlas>(atlasPath);
+                if (atlas == null) continue;
+
+                var packables = atlas.GetPackables();
+                foreach (var packable in packables)
+                {
+                    var packablePath = AssetDatabase.GetAssetPath(packable);
+
+                    // Direct match
+                    if (packablePath == texturePath)
+                        return true;
+
+                    // Folder match — if the packable is a folder containing the texture
+                    if (AssetDatabase.IsValidFolder(packablePath) &&
+                        texturePath.StartsWith(packablePath + "/"))
+                        return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static string GetHierarchyPath(GameObject go)
+        {
+            var path = go.name;
+            var parent = go.transform.parent;
+            while (parent != null)
+            {
+                path = parent.name + "/" + path;
+                parent = parent.parent;
+            }
+            return path;
+        }
+
+        // --- Swapping ---
+
+        /// <summary>
+        /// Perform the swap for candidates that have KTX2 files available.
+        /// Groups by asset path (scene or prefab) and processes each.
+        /// </summary>
+        public static SwapReport PerformSwap(List<SwapCandidate> candidates)
+        {
+            var report = new SwapReport();
+
+            var ktx2Type = GetKtx2ImageType();
+            if (ktx2Type == null)
+            {
+                Debug.LogError("[Yes2SDK] Cannot swap: Yes2SDKKtx2Image type not found. Is com.unity.cloud.ktx installed?");
+                return report;
+            }
+
+            // Group by asset path
+            var grouped = candidates.GroupBy(c => c.assetPath);
+
+            int totalGroups = grouped.Count();
+            int groupIndex = 0;
+
+            foreach (var group in grouped)
+            {
+                var assetPath = group.Key;
+                groupIndex++;
+
+                EditorUtility.DisplayProgressBar("Swapping Textures",
+                    $"Processing {Path.GetFileName(assetPath)}... ({groupIndex}/{totalGroups})",
+                    (float)groupIndex / totalGroups);
+
+                bool isPrefab = assetPath.EndsWith(".prefab");
+
+                if (isPrefab)
+                {
+                    SwapInPrefab(assetPath, group.ToList(), report, ktx2Type);
+                }
+                else
+                {
+                    SwapInScene(assetPath, group.ToList(), report, ktx2Type);
+                }
+            }
+
+            EditorUtility.ClearProgressBar();
+            AssetDatabase.SaveAssets();
+
+            return report;
+        }
+
+        private static void SwapInScene(string scenePath, List<SwapCandidate> candidates,
+            SwapReport report, Type ktx2Type)
+        {
+            // Ensure the scene is open
+            var scene = SceneManager.GetActiveScene();
+            if (scene.path != scenePath)
+            {
+                scene = EditorSceneManager.OpenScene(scenePath, OpenSceneMode.Single);
+            }
+
+            var rootObjects = scene.GetRootGameObjects();
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate.inAtlas)
+                {
+                    report.skippedInAtlas++;
+                    continue;
+                }
+                if (!candidate.ktx2Exists)
+                {
+                    report.skippedMissingKtx2++;
+                    continue;
+                }
+
+                var go = FindGameObjectByPath(rootObjects, candidate.gameObjectPath);
+                if (go == null)
+                {
+                    Debug.LogWarning($"[Yes2SDK] Could not find {candidate.gameObjectPath} in {scenePath}");
+                    continue;
+                }
+
+                if (go.GetComponent(ktx2Type) != null)
+                {
+                    report.skippedAlreadySwapped++;
+                    continue;
+                }
+
+                SwapComponent(go, candidate, ktx2Type);
+                report.swapped++;
+            }
+
+            EditorSceneManager.MarkSceneDirty(scene);
+            EditorSceneManager.SaveScene(scene);
+        }
+
+        private static void SwapInPrefab(string prefabPath, List<SwapCandidate> candidates,
+            SwapReport report, Type ktx2Type)
+        {
+            var prefabRoot = PrefabUtility.LoadPrefabContents(prefabPath);
+            if (prefabRoot == null) return;
+
+            bool modified = false;
+
+            foreach (var candidate in candidates)
+            {
+                if (candidate.inAtlas)
+                {
+                    report.skippedInAtlas++;
+                    continue;
+                }
+                if (!candidate.ktx2Exists)
+                {
+                    report.skippedMissingKtx2++;
+                    continue;
+                }
+
+                var go = FindGameObjectByPath(new[] { prefabRoot }, candidate.gameObjectPath);
+                if (go == null)
+                {
+                    Debug.LogWarning($"[Yes2SDK] Could not find {candidate.gameObjectPath} in {prefabPath}");
+                    continue;
+                }
+
+                if (go.GetComponent(ktx2Type) != null)
+                {
+                    report.skippedAlreadySwapped++;
+                    continue;
+                }
+
+                SwapComponent(go, candidate, ktx2Type);
+                report.swapped++;
+                modified = true;
+            }
+
+            if (modified)
+                PrefabUtility.SaveAsPrefabAsset(prefabRoot, prefabPath);
+
+            PrefabUtility.UnloadPrefabContents(prefabRoot);
+        }
+
+        private static void SwapComponent(GameObject go, SwapCandidate candidate, Type ktx2Type)
+        {
+            // Add KTX2 loader via reflection
+            var loader = go.AddComponent(ktx2Type);
+
+            // Set Ktx2Path property
+            if (_ktx2PathProperty == null)
+                _ktx2PathProperty = ktx2Type.GetProperty("Ktx2Path");
+            _ktx2PathProperty?.SetValue(loader, candidate.ktx2Path);
+
+            // Clear original texture reference
+            switch (candidate.componentType)
+            {
+                case "RawImage":
+                    var rawImage = go.GetComponent<RawImage>();
+                    if (rawImage != null)
+                        rawImage.texture = null;
+                    break;
+
+                case "Image":
+                    var image = go.GetComponent<Image>();
+                    if (image != null)
+                        image.sprite = null;
+                    break;
+
+                case "SpriteRenderer":
+                    var spriteRenderer = go.GetComponent<SpriteRenderer>();
+                    if (spriteRenderer != null)
+                        spriteRenderer.sprite = null;
+                    break;
+            }
+
+            Debug.Log($"[Yes2SDK] Swapped: {candidate.gameObjectPath} ({candidate.componentType}) -> {candidate.ktx2Path}");
+        }
+
+        private static GameObject FindGameObjectByPath(GameObject[] roots, string hierarchyPath)
+        {
+            foreach (var root in roots)
+            {
+                var result = FindByPathRecursive(root, hierarchyPath);
+                if (result != null)
+                    return result;
+            }
+            return null;
+        }
+
+        private static GameObject FindByPathRecursive(GameObject go, string targetPath)
+        {
+            if (GetHierarchyPath(go) == targetPath)
+                return go;
+
+            for (int i = 0; i < go.transform.childCount; i++)
+            {
+                var result = FindByPathRecursive(go.transform.GetChild(i).gameObject, targetPath);
+                if (result != null)
+                    return result;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Editor/Yes2SDKTextureSwapTool.cs.meta
+++ b/Editor/Yes2SDKTextureSwapTool.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 078882032d65045c287934cd10d4c51c

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -1,6 +1,8 @@
 using UnityEngine;
 using UnityEditor;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace Yes2SDK.Editor
 {
@@ -12,11 +14,42 @@ namespace Yes2SDK.Editor
         private TargetPlatform _selectedPlatform = TargetPlatform.Debug;
         private string _buildPath = "Builds";
         private bool _showDebugLogs = true;
-        private bool _showBuildSettings = true;
-        private bool _showSDKSettings = true;
-        private bool _showUtilities = true;
         private Vector2 _scrollPosition;
         private bool _isSetupComplete;
+
+        // Tab state
+        private int _selectedTab;
+        private static readonly string[] _tabLabels = { "Build", "Optimization", "Tools" };
+
+        // Sprite Atlas tool state
+        private string _spriteAtlasSourceFolder = "Assets/Sprites";
+        private string _spriteAtlasOutputDir = "Assets/SpriteAtlases";
+        private bool _showSpriteAtlasAdvanced;
+        private int _spriteAtlasPadding = 4;
+        private int _spriteAtlasMaxSize = 2048;
+        private int _spriteAtlasCompressionQuality = 50;
+        private List<Yes2SDKSpriteAtlasTool.ScanResult> _spriteAtlasScanResults;
+        private List<Yes2SDKSpriteAtlasTool.AtlasReport> _spriteAtlasReports;
+
+        // KTX2 tool state
+        private Yes2SDKKtx2Tool.Ktx2Preset _ktx2Preset = Yes2SDKKtx2Tool.Ktx2Preset.UASTC_Zstd;
+        private int _ktx2UastcQuality = 2;
+        private int _ktx2ZstdLevel = 3;
+        private int _ktx2Etc1sQuality = 128;
+        private int _ktx2Etc1sCompressionLevel = 2;
+        private string _toktxPath;
+        private bool _toktxChecked;
+        private string _toktxVersion;
+        private bool _ktxPackageInstalled;
+        private bool _ktxPackageChecked;
+        private string _ktx2SourceFolder = "Assets/Textures";
+        private List<Yes2SDKKtx2Tool.ConversionResult> _ktx2Results;
+
+        // Texture swap tool state
+        private Yes2SDKTextureSwapTool.ScanScope _swapScope = Yes2SDKTextureSwapTool.ScanScope.ActiveScene;
+        private string _swapPrefabFolder = "Assets/Prefabs";
+        private List<Yes2SDKTextureSwapTool.SwapCandidate> _swapCandidates;
+        private Yes2SDKTextureSwapTool.SwapReport _swapReport;
 
         [MenuItem("Yes2SDK/Settings", false, 0)]
         public static void ShowWindow()
@@ -38,9 +71,30 @@ namespace Yes2SDK.Editor
             _selectedPlatform = (TargetPlatform)EditorPrefs.GetInt("Yes2SDK_SelectedPlatform", (int)TargetPlatform.Debug);
             _buildPath = EditorPrefs.GetString("Yes2SDK_BuildPath", "Builds");
             _showDebugLogs = EditorPrefs.GetBool("Yes2SDK_ShowDebugLogs", true);
+            _selectedTab = EditorPrefs.GetInt("Yes2SDK_SelectedTab", 0);
+
+            // Load utility preferences
+            _spriteAtlasSourceFolder = EditorPrefs.GetString("Yes2SDK_SpriteAtlasSource", "Assets/Sprites");
+            _spriteAtlasOutputDir = EditorPrefs.GetString("Yes2SDK_SpriteAtlasOutput", "Assets/SpriteAtlases");
+            _ktx2SourceFolder = EditorPrefs.GetString("Yes2SDK_Ktx2Source", "Assets/Textures");
+            _ktx2Preset = (Yes2SDKKtx2Tool.Ktx2Preset)EditorPrefs.GetInt("Yes2SDK_Ktx2Preset", 0);
 
             // Check setup status
             RefreshSetupStatus();
+
+            // Detect KTX2 prerequisites on window open
+            RefreshKtx2Status();
+        }
+
+        private void RefreshKtx2Status()
+        {
+            _toktxPath = Yes2SDKKtx2Tool.FindToktx();
+            if (_toktxPath != null)
+                _toktxVersion = Yes2SDKKtx2Tool.ValidateToktx(_toktxPath);
+            _toktxChecked = true;
+
+            _ktxPackageInstalled = Yes2SDKKtx2Tool.IsKtxPackageInstalled();
+            _ktxPackageChecked = true;
         }
 
         private void OnFocus()
@@ -56,30 +110,50 @@ namespace Yes2SDK.Editor
 
         private void OnGUI()
         {
-            _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
-
             DrawHeader();
             EditorGUILayout.Space(10);
 
-            // Show setup section if not complete
+            // Show setup section above tabs if not complete
             if (!_isSetupComplete)
             {
                 DrawSetupSection();
                 EditorGUILayout.Space(10);
             }
 
-            DrawSDKSettingsSection();
-            EditorGUILayout.Space(10);
+            // Tab toolbar
+            EditorGUI.BeginChangeCheck();
+            _selectedTab = GUILayout.Toolbar(_selectedTab, _tabLabels);
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorPrefs.SetInt("Yes2SDK_SelectedTab", _selectedTab);
+            }
 
-            DrawBuildSection();
-            EditorGUILayout.Space(10);
+            EditorGUILayout.Space(5);
 
-            DrawUtilitiesSection();
-            EditorGUILayout.Space(10);
+            _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
 
-            DrawFooter();
+            switch (_selectedTab)
+            {
+                case 0:
+                    DrawSDKSettingsSection();
+                    EditorGUILayout.Space(10);
+                    DrawBuildSection();
+                    break;
+                case 1:
+                    DrawSpriteAtlasUtility();
+                    EditorGUILayout.Space(10);
+                    DrawKtx2Utility();
+                    break;
+                case 2:
+                    DrawToolsSection();
+                    break;
+            }
+
+            EditorGUILayout.Space(10);
 
             EditorGUILayout.EndScrollView();
+
+            DrawFooter();
         }
 
         private void DrawHeader()
@@ -164,133 +238,122 @@ namespace Yes2SDK.Editor
 
         private void DrawSDKSettingsSection()
         {
-            _showSDKSettings = EditorGUILayout.BeginFoldoutHeaderGroup(_showSDKSettings, "SDK Settings");
+            EditorGUILayout.LabelField("SDK Settings", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
-            if (_showSDKSettings)
+            EditorGUI.BeginChangeCheck();
+            _showDebugLogs = EditorGUILayout.Toggle("Show Debug Logs", _showDebugLogs);
+            if (EditorGUI.EndChangeCheck())
             {
-                EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-
-                EditorGUI.BeginChangeCheck();
-                _showDebugLogs = EditorGUILayout.Toggle("Show Debug Logs", _showDebugLogs);
-                if (EditorGUI.EndChangeCheck())
-                {
-                    EditorPrefs.SetBool("Yes2SDK_ShowDebugLogs", _showDebugLogs);
-                }
-
-                EditorGUILayout.Space(5);
-                EditorGUILayout.HelpBox(
-                    "Enable detailed logging in the Console for debugging purposes.",
-                    MessageType.Info);
-
-                EditorGUILayout.EndVertical();
+                EditorPrefs.SetBool("Yes2SDK_ShowDebugLogs", _showDebugLogs);
             }
 
-            EditorGUILayout.EndFoldoutHeaderGroup();
+            EditorGUILayout.Space(5);
+            EditorGUILayout.HelpBox(
+                "Enable detailed logging in the Console for debugging purposes.",
+                MessageType.Info);
+
+            EditorGUILayout.EndVertical();
         }
 
         private void DrawBuildSection()
         {
-            _showBuildSettings = EditorGUILayout.BeginFoldoutHeaderGroup(_showBuildSettings, "Build Settings");
+            EditorGUILayout.LabelField("Build Settings", EditorStyles.boldLabel);
 
-            if (_showBuildSettings)
+            // Disable build section if setup not complete
+            EditorGUI.BeginDisabledGroup(!_isSetupComplete);
+
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            // Platform selection
+            EditorGUI.BeginChangeCheck();
+            _selectedPlatform = (TargetPlatform)EditorGUILayout.EnumPopup("Target Platform", _selectedPlatform);
+            if (EditorGUI.EndChangeCheck())
             {
-                // Disable build section if setup not complete
-                EditorGUI.BeginDisabledGroup(!_isSetupComplete);
-
-                EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-
-                // Platform selection
-                EditorGUI.BeginChangeCheck();
-                _selectedPlatform = (TargetPlatform)EditorGUILayout.EnumPopup("Target Platform", _selectedPlatform);
-                if (EditorGUI.EndChangeCheck())
-                {
-                    EditorPrefs.SetInt("Yes2SDK_SelectedPlatform", (int)_selectedPlatform);
-                }
-
-                // Build path
-                EditorGUILayout.BeginHorizontal();
-                EditorGUI.BeginChangeCheck();
-                _buildPath = EditorGUILayout.TextField("Build Path", _buildPath);
-                if (EditorGUI.EndChangeCheck())
-                {
-                    EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
-                }
-                if (GUILayout.Button("...", GUILayout.Width(30)))
-                {
-                    string path = EditorUtility.SaveFolderPanel("Select Build Folder", _buildPath, "");
-                    if (!string.IsNullOrEmpty(path))
-                    {
-                        // Make relative if inside project
-                        string projectPath = Directory.GetParent(Application.dataPath).FullName;
-                        if (path.StartsWith(Application.dataPath))
-                        {
-                            path = "Assets" + path.Substring(Application.dataPath.Length);
-                        }
-                        else if (path.StartsWith(projectPath))
-                        {
-                            path = path.Substring(projectPath.Length + 1);
-                        }
-                        _buildPath = path;
-                        EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
-                    }
-                }
-                EditorGUILayout.EndHorizontal();
-
-                EditorGUILayout.Space(5);
-
-                // Platform info box
-                var config = BuildConfig.GetConfig(_selectedPlatform);
-                DrawPlatformInfo(config);
-
-                EditorGUILayout.Space(10);
-
-                // Build buttons
-                EditorGUILayout.BeginHorizontal();
-
-                if (GUILayout.Button("Apply Settings", GUILayout.Height(30)))
-                {
-                    ApplyBuildSettings();
-                }
-
-                GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
-                if (GUILayout.Button("Build", GUILayout.Height(30)))
-                {
-                    BuildForPlatform();
-                }
-                GUI.backgroundColor = Color.white;
-
-                EditorGUILayout.EndHorizontal();
-
-                // Build & Run button
-                if (GUILayout.Button("Build and Run", GUILayout.Height(25)))
-                {
-                    BuildForPlatform(runAfterBuild: true);
-                }
-
-                EditorGUILayout.Space(5);
-
-                // Reinstall templates link
-                EditorGUILayout.BeginHorizontal();
-                GUILayout.FlexibleSpace();
-                if (GUILayout.Button("Reinstall Templates", EditorStyles.linkLabel))
-                {
-                    ReinstallTemplates();
-                }
-                GUILayout.FlexibleSpace();
-                EditorGUILayout.EndHorizontal();
-
-                EditorGUILayout.EndVertical();
-
-                EditorGUI.EndDisabledGroup();
-
-                // Show hint if disabled
-                if (!_isSetupComplete)
-                {
-                    EditorGUILayout.HelpBox("Complete setup above to enable build options.", MessageType.Info);
-                }
+                EditorPrefs.SetInt("Yes2SDK_SelectedPlatform", (int)_selectedPlatform);
             }
 
-            EditorGUILayout.EndFoldoutHeaderGroup();
+            // Build path
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginChangeCheck();
+            _buildPath = EditorGUILayout.TextField("Build Path", _buildPath);
+            if (EditorGUI.EndChangeCheck())
+            {
+                EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
+            }
+            if (GUILayout.Button("...", GUILayout.Width(30)))
+            {
+                string path = EditorUtility.SaveFolderPanel("Select Build Folder", _buildPath, "");
+                if (!string.IsNullOrEmpty(path))
+                {
+                    // Make relative if inside project
+                    string projectPath = Directory.GetParent(Application.dataPath).FullName;
+                    if (path.StartsWith(Application.dataPath))
+                    {
+                        path = "Assets" + path.Substring(Application.dataPath.Length);
+                    }
+                    else if (path.StartsWith(projectPath))
+                    {
+                        path = path.Substring(projectPath.Length + 1);
+                    }
+                    _buildPath = path;
+                    EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(5);
+
+            // Platform info box
+            var config = BuildConfig.GetConfig(_selectedPlatform);
+            DrawPlatformInfo(config);
+
+            EditorGUILayout.Space(10);
+
+            // Build buttons
+            EditorGUILayout.BeginHorizontal();
+
+            if (GUILayout.Button("Apply Settings", GUILayout.Height(30)))
+            {
+                ApplyBuildSettings();
+            }
+
+            GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
+            if (GUILayout.Button("Build", GUILayout.Height(30)))
+            {
+                BuildForPlatform();
+            }
+            GUI.backgroundColor = Color.white;
+
+            EditorGUILayout.EndHorizontal();
+
+            // Build & Run button
+            if (GUILayout.Button("Build and Run", GUILayout.Height(25)))
+            {
+                BuildForPlatform(runAfterBuild: true);
+            }
+
+            EditorGUILayout.Space(5);
+
+            // Reinstall templates link
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Reinstall Templates", EditorStyles.linkLabel))
+            {
+                ReinstallTemplates();
+            }
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.EndVertical();
+
+            EditorGUI.EndDisabledGroup();
+
+            // Show hint if disabled
+            if (!_isSetupComplete)
+            {
+                EditorGUILayout.HelpBox("Complete setup above to enable build options.", MessageType.Info);
+            }
         }
 
         private void DrawPlatformInfo(BuildConfig config)
@@ -312,34 +375,539 @@ namespace Yes2SDK.Editor
             EditorGUILayout.EndVertical();
         }
 
-        private void DrawUtilitiesSection()
+        private void DrawToolsSection()
         {
-            _showUtilities = EditorGUILayout.BeginFoldoutHeaderGroup(_showUtilities, "Utilities");
+            EditorGUILayout.LabelField("Tools", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField("Coming Soon", EditorStyles.centeredGreyMiniLabel);
+            GUI.enabled = false;
+            GUILayout.Button("Letterbox (Portrait Mode)");
+            GUILayout.Button("Safe Area Handler");
+            GUILayout.Button("Build Size Analyzer");
+            GUI.enabled = true;
+            EditorGUILayout.EndVertical();
+        }
 
-            if (_showUtilities)
+        // ─── Sprite Atlas Utility ───────────────────────────────────────
+
+        private void DrawSpriteAtlasUtility()
+        {
+            EditorGUILayout.LabelField("Sprite Atlas Automation", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            EditorGUILayout.HelpBox(
+                "Scan for loose sprites and create WebGL-optimized Sprite Atlases.\n" +
+                "Reduces draw calls and texture overhead for smaller, faster builds.",
+                MessageType.Info);
+
+            EditorGUILayout.Space(5);
+
+            // Source folder
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginChangeCheck();
+            _spriteAtlasSourceFolder = EditorGUILayout.TextField("Source Folder", _spriteAtlasSourceFolder);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetString("Yes2SDK_SpriteAtlasSource", _spriteAtlasSourceFolder);
+            if (GUILayout.Button("...", GUILayout.Width(30)))
             {
-                EditorGUI.BeginDisabledGroup(!_isSetupComplete);
+                var path = EditorUtility.OpenFolderPanel("Select Sprite Source Folder", "Assets", "");
+                if (!string.IsNullOrEmpty(path) && path.Contains(Application.dataPath))
+                {
+                    _spriteAtlasSourceFolder = "Assets" + path.Substring(Application.dataPath.Length);
+                    EditorPrefs.SetString("Yes2SDK_SpriteAtlasSource", _spriteAtlasSourceFolder);
+                }
+            }
+            EditorGUILayout.EndHorizontal();
 
-                EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            // Output directory
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginChangeCheck();
+            _spriteAtlasOutputDir = EditorGUILayout.TextField("Output Directory", _spriteAtlasOutputDir);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetString("Yes2SDK_SpriteAtlasOutput", _spriteAtlasOutputDir);
+            if (GUILayout.Button("...", GUILayout.Width(30)))
+            {
+                var path = EditorUtility.OpenFolderPanel("Select Atlas Output Folder", "Assets", "");
+                if (!string.IsNullOrEmpty(path) && path.Contains(Application.dataPath))
+                {
+                    _spriteAtlasOutputDir = "Assets" + path.Substring(Application.dataPath.Length);
+                    EditorPrefs.SetString("Yes2SDK_SpriteAtlasOutput", _spriteAtlasOutputDir);
+                }
+            }
+            EditorGUILayout.EndHorizontal();
 
-                EditorGUILayout.LabelField("Coming Soon", EditorStyles.centeredGreyMiniLabel);
-                EditorGUILayout.Space(5);
-
-                GUI.enabled = false;
-                GUILayout.Button("Letterbox (Portrait Mode)");
-                GUILayout.Button("Safe Area Handler");
-                GUILayout.Button("Build Size Analyzer");
-                GUI.enabled = true;
-
-                EditorGUILayout.Space(5);
-                EditorGUILayout.HelpBox("Utility tools will be added in future updates.", MessageType.Info);
-
-                EditorGUILayout.EndVertical();
-
-                EditorGUI.EndDisabledGroup();
+            // Advanced settings
+            _showSpriteAtlasAdvanced = EditorGUILayout.Foldout(_showSpriteAtlasAdvanced, "Advanced Settings");
+            if (_showSpriteAtlasAdvanced)
+            {
+                EditorGUI.indentLevel++;
+                _spriteAtlasPadding = EditorGUILayout.IntSlider("Padding", _spriteAtlasPadding, 1, 8);
+                _spriteAtlasMaxSize = EditorGUILayout.IntPopup("Max Texture Size",
+                    _spriteAtlasMaxSize,
+                    new[] { "512", "1024", "2048", "4096" },
+                    new[] { 512, 1024, 2048, 4096 });
+                _spriteAtlasCompressionQuality = EditorGUILayout.IntSlider("Crunch Quality", _spriteAtlasCompressionQuality, 0, 100);
+                EditorGUI.indentLevel--;
             }
 
-            EditorGUILayout.EndFoldoutHeaderGroup();
+            EditorGUILayout.Space(5);
+
+            // Scan button
+            if (GUILayout.Button("Scan for Loose Sprites", GUILayout.Height(25)))
+            {
+                _spriteAtlasScanResults = Yes2SDKSpriteAtlasTool.ScanForLooseSprites(
+                    new[] { _spriteAtlasSourceFolder });
+                _spriteAtlasReports = null;
+            }
+
+            // Scan results
+            if (_spriteAtlasScanResults != null)
+            {
+                EditorGUILayout.Space(3);
+
+                if (_spriteAtlasScanResults.Count == 0)
+                {
+                    EditorGUILayout.HelpBox(
+                        "No loose sprites found. All sprites are already in atlases, or no sprites exist in the source folder.",
+                        MessageType.Info);
+                }
+                else
+                {
+                    int totalSprites = _spriteAtlasScanResults.Sum(r => r.spritePaths.Count);
+                    EditorGUILayout.LabelField(
+                        $"Found {totalSprites} loose sprites in {_spriteAtlasScanResults.Count} folders:",
+                        EditorStyles.boldLabel);
+
+                    EditorGUI.indentLevel++;
+                    foreach (var result in _spriteAtlasScanResults)
+                    {
+                        EditorGUILayout.LabelField($"{result.folderName}/", $"{result.spritePaths.Count} sprites");
+                    }
+                    EditorGUI.indentLevel--;
+
+                    EditorGUILayout.Space(5);
+
+                    // Create button
+                    GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
+                    if (GUILayout.Button($"Create {_spriteAtlasScanResults.Count} Atlases", GUILayout.Height(28)))
+                    {
+                        var settings = new Yes2SDKSpriteAtlasTool.Settings
+                        {
+                            padding = _spriteAtlasPadding,
+                            maxTextureSize = _spriteAtlasMaxSize,
+                            compressionQuality = _spriteAtlasCompressionQuality
+                        };
+
+                        _spriteAtlasReports = Yes2SDKSpriteAtlasTool.CreateAtlases(
+                            _spriteAtlasScanResults, settings, _spriteAtlasOutputDir);
+
+                        _spriteAtlasScanResults = null;
+                    }
+                    GUI.backgroundColor = Color.white;
+                }
+            }
+
+            // Creation report
+            if (_spriteAtlasReports != null && _spriteAtlasReports.Count > 0)
+            {
+                EditorGUILayout.Space(3);
+
+                int created = _spriteAtlasReports.Count(r => r.created && !r.alreadyExisted);
+                int updated = _spriteAtlasReports.Count(r => r.created && r.alreadyExisted);
+                int totalSprites = _spriteAtlasReports.Sum(r => r.spriteCount);
+
+                EditorGUILayout.HelpBox(
+                    $"Done! {created} atlases created, {updated} updated.\n" +
+                    $"{totalSprites} sprites packed. Estimated draw call savings: ~{Mathf.Max(0, totalSprites - _spriteAtlasReports.Count)}.",
+                    MessageType.Info);
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        // ─── KTX2 Texture Compression ───────────────────────────────────
+
+        private void DrawKtx2Utility()
+        {
+            EditorGUILayout.LabelField("KTX2 Texture Compression", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            EditorGUILayout.HelpBox(
+                "Convert textures to KTX2 (Basis Universal). Transcodes at runtime " +
+                "to the optimal GPU format per device (BC7 desktop, ETC2/ASTC mobile).\n" +
+                "Smaller on disk than ETC2 Crunched, universal browser support from a single build.",
+                MessageType.Info);
+
+            EditorGUILayout.Space(5);
+
+            // Prerequisites
+            DrawKtx2Prerequisites();
+
+            bool ready = _toktxPath != null && _ktxPackageInstalled;
+
+            EditorGUI.BeginDisabledGroup(!ready);
+
+            EditorGUILayout.Space(5);
+
+            // Source folder
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginChangeCheck();
+            _ktx2SourceFolder = EditorGUILayout.TextField("Source Folder", _ktx2SourceFolder);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetString("Yes2SDK_Ktx2Source", _ktx2SourceFolder);
+            if (GUILayout.Button("...", GUILayout.Width(30)))
+            {
+                var path = EditorUtility.OpenFolderPanel("Select Texture Source Folder", "Assets", "");
+                if (!string.IsNullOrEmpty(path) && path.Contains(Application.dataPath))
+                {
+                    _ktx2SourceFolder = "Assets" + path.Substring(Application.dataPath.Length);
+                    EditorPrefs.SetString("Yes2SDK_Ktx2Source", _ktx2SourceFolder);
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.LabelField("", "Point to your original textures (PNG/JPG), not atlas output folders.", EditorStyles.miniLabel);
+
+            // Preset
+            EditorGUI.BeginChangeCheck();
+            _ktx2Preset = (Yes2SDKKtx2Tool.Ktx2Preset)EditorGUILayout.EnumPopup("Compression Preset", _ktx2Preset);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetInt("Yes2SDK_Ktx2Preset", (int)_ktx2Preset);
+
+            // Preset-specific settings
+            EditorGUI.indentLevel++;
+            if (_ktx2Preset == Yes2SDKKtx2Tool.Ktx2Preset.UASTC_Zstd)
+            {
+                _ktx2UastcQuality = EditorGUILayout.IntSlider("UASTC Quality", _ktx2UastcQuality, 0, 4);
+                EditorGUILayout.LabelField("", "0 = fastest encode, lowest quality.  4 = slowest encode, best quality.", EditorStyles.miniLabel);
+
+                _ktx2ZstdLevel = EditorGUILayout.IntSlider("Zstd Level", _ktx2ZstdLevel, 1, 22);
+                EditorGUILayout.LabelField("", "1 = fastest, larger file.  22 = slowest, smallest file. 3-6 recommended.", EditorStyles.miniLabel);
+
+                EditorGUILayout.Space(2);
+                EditorGUILayout.LabelField("", "UASTC: Near-lossless quality, fast GPU transcode. Best for most textures.", EditorStyles.miniLabel);
+            }
+            else
+            {
+                _ktx2Etc1sQuality = EditorGUILayout.IntSlider("ETC1S Quality", _ktx2Etc1sQuality, 1, 255);
+                EditorGUILayout.LabelField("", "1 = smallest file, most artifacts.  255 = largest file, best quality.", EditorStyles.miniLabel);
+
+                _ktx2Etc1sCompressionLevel = EditorGUILayout.IntSlider("Compression Level", _ktx2Etc1sCompressionLevel, 0, 5);
+                EditorGUILayout.LabelField("", "0 = fastest encode.  5 = slowest encode, best compression ratio.", EditorStyles.miniLabel);
+
+                EditorGUILayout.Space(2);
+                EditorGUILayout.LabelField("", "ETC1S: Maximum compression, lower quality. Best for color/photo textures.", EditorStyles.miniLabel);
+            }
+            EditorGUI.indentLevel--;
+
+            EditorGUILayout.Space(5);
+
+            // Convert button
+            GUI.backgroundColor = new Color(0.3f, 0.7f, 1f);
+            if (GUILayout.Button("Convert All Textures in Folder", GUILayout.Height(28)))
+            {
+                var textures = Yes2SDKKtx2Tool.FindTexturesInFolder(_ktx2SourceFolder);
+                if (textures.Length == 0)
+                {
+                    EditorUtility.DisplayDialog("Yes2SDK",
+                        $"No textures found in {_ktx2SourceFolder}.",
+                        "OK");
+                }
+                else
+                {
+                    bool proceed = EditorUtility.DisplayDialog("Yes2SDK",
+                        $"Convert {textures.Length} textures to KTX2?\n\n" +
+                        $"Preset: {_ktx2Preset}\n" +
+                        $"Output: StreamingAssets/ktx2/",
+                        "Convert", "Cancel");
+
+                    if (proceed)
+                    {
+                        var settings = new Yes2SDKKtx2Tool.Settings
+                        {
+                            preset = _ktx2Preset,
+                            uastcQuality = _ktx2UastcQuality,
+                            zstdLevel = _ktx2ZstdLevel,
+                            etc1sQuality = _ktx2Etc1sQuality,
+                            etc1sCompressionLevel = _ktx2Etc1sCompressionLevel
+                        };
+
+                        _ktx2Results = Yes2SDKKtx2Tool.BatchConvert(textures, settings, _toktxPath);
+                    }
+                }
+            }
+            GUI.backgroundColor = Color.white;
+
+            EditorGUI.EndDisabledGroup();
+
+            // Conversion report
+            if (_ktx2Results != null && _ktx2Results.Count > 0)
+            {
+                EditorGUILayout.Space(3);
+
+                int succeeded = _ktx2Results.Count(r => r.success);
+                int failed = _ktx2Results.Count(r => !r.success);
+                long totalOriginal = _ktx2Results.Where(r => r.success).Sum(r => r.originalSize);
+                long totalKtx2 = _ktx2Results.Where(r => r.success).Sum(r => r.ktx2Size);
+                float avgRatio = totalKtx2 > 0 ? (float)totalOriginal / totalKtx2 : 0;
+
+                var msg = $"Converted {succeeded}/{_ktx2Results.Count} textures.\n";
+                if (succeeded > 0)
+                {
+                    msg += $"Avg compression: {avgRatio:F1}x. " +
+                           $"Saved: {FormatBytes(totalOriginal - totalKtx2)}.";
+                }
+                if (failed > 0)
+                    msg += $"\n{failed} failed — check Console for details.";
+
+                EditorGUILayout.HelpBox(msg,
+                    failed > 0 ? MessageType.Warning : MessageType.Info);
+            }
+
+            // ─── Swap Texture References ────────────────────────────────
+            EditorGUILayout.Space(10);
+            if (_ktxPackageInstalled)
+            {
+                DrawSwapTextureSection();
+            }
+            else
+            {
+                EditorGUILayout.LabelField("Swap Texture References", EditorStyles.boldLabel);
+                EditorGUILayout.HelpBox(
+                    "Install com.unity.cloud.ktx to enable runtime KTX2 loading and texture swapping.",
+                    MessageType.Info);
+                if (GUILayout.Button("Install com.unity.cloud.ktx"))
+                {
+                    Yes2SDKKtx2Tool.InstallKtxPackage();
+                    RefreshKtx2Status();
+                }
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawSwapTextureSection()
+        {
+            EditorGUILayout.LabelField("Swap Texture References", EditorStyles.boldLabel);
+
+            EditorGUILayout.HelpBox(
+                "Replace texture references in scenes/prefabs with KTX2 runtime loaders.\n" +
+                "Original textures are cleared so they're excluded from Build.data, " +
+                "reducing initial download size.",
+                MessageType.Info);
+
+            EditorGUILayout.Space(3);
+
+            // Scope selection
+            _swapScope = (Yes2SDKTextureSwapTool.ScanScope)EditorGUILayout.EnumPopup("Scan Scope", _swapScope);
+
+            // Prefab folder picker (only shown for PrefabsInFolder scope)
+            if (_swapScope == Yes2SDKTextureSwapTool.ScanScope.PrefabsInFolder)
+            {
+                EditorGUILayout.BeginHorizontal();
+                _swapPrefabFolder = EditorGUILayout.TextField("Prefab Folder", _swapPrefabFolder);
+                if (GUILayout.Button("...", GUILayout.Width(30)))
+                {
+                    var path = EditorUtility.OpenFolderPanel("Select Prefab Folder", "Assets", "");
+                    if (!string.IsNullOrEmpty(path) && path.Contains(Application.dataPath))
+                    {
+                        _swapPrefabFolder = "Assets" + path.Substring(Application.dataPath.Length);
+                    }
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+
+            EditorGUILayout.Space(3);
+
+            // Scan button
+            if (GUILayout.Button("Scan", GUILayout.Height(25)))
+            {
+                _swapReport = null;
+
+                switch (_swapScope)
+                {
+                    case Yes2SDKTextureSwapTool.ScanScope.ActiveScene:
+                        _swapCandidates = Yes2SDKTextureSwapTool.ScanActiveScene();
+                        break;
+                    case Yes2SDKTextureSwapTool.ScanScope.AllBuildScenes:
+                        _swapCandidates = Yes2SDKTextureSwapTool.ScanAllBuildScenes();
+                        break;
+                    case Yes2SDKTextureSwapTool.ScanScope.PrefabsInFolder:
+                        _swapCandidates = Yes2SDKTextureSwapTool.ScanPrefabs(_swapPrefabFolder);
+                        break;
+                }
+            }
+
+            // Scan results
+            if (_swapCandidates != null)
+            {
+                EditorGUILayout.Space(3);
+
+                if (_swapCandidates.Count == 0)
+                {
+                    EditorGUILayout.HelpBox(
+                        "No swappable textures found. Either all textures are already swapped, " +
+                        "or no matching KTX2 files exist.",
+                        MessageType.Info);
+                }
+                else
+                {
+                    int ready = _swapCandidates.Count(c => c.ktx2Exists && !c.inAtlas);
+                    int missingKtx2 = _swapCandidates.Count(c => !c.ktx2Exists && !c.inAtlas);
+                    int inAtlas = _swapCandidates.Count(c => c.inAtlas);
+
+                    var summary = $"Found {_swapCandidates.Count} texture references:";
+                    summary += $"\n  {ready} ready to swap";
+                    if (missingKtx2 > 0)
+                        summary += $"\n  {missingKtx2} missing KTX2 (convert first)";
+                    if (inAtlas > 0)
+                        summary += $"\n  {inAtlas} skipped (in SpriteAtlas)";
+
+                    // Component type breakdown
+                    var byType = _swapCandidates.Where(c => c.ktx2Exists && !c.inAtlas)
+                        .GroupBy(c => c.componentType);
+                    foreach (var group in byType)
+                    {
+                        summary += $"\n  {group.Key}: {group.Count()}";
+                    }
+
+                    EditorGUILayout.HelpBox(summary,
+                        missingKtx2 > 0 ? MessageType.Warning : MessageType.Info);
+
+                    if (missingKtx2 > 0)
+                    {
+                        EditorGUILayout.LabelField("",
+                            "Convert missing textures using the tool above before swapping.",
+                            EditorStyles.miniLabel);
+                    }
+
+                    EditorGUILayout.Space(3);
+
+                    // Swap button
+                    EditorGUI.BeginDisabledGroup(ready == 0);
+                    GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
+                    if (GUILayout.Button($"Swap {ready} Textures", GUILayout.Height(28)))
+                    {
+                        bool proceed = EditorUtility.DisplayDialog("Yes2SDK",
+                            $"This will:\n" +
+                            $"- Add Yes2SDKKtx2Image to {ready} GameObjects\n" +
+                            $"- Clear original texture references\n\n" +
+                            "Scenes/prefabs will be saved. This can be undone with Ctrl+Z before saving.",
+                            "Swap", "Cancel");
+
+                        if (proceed)
+                        {
+                            _swapReport = Yes2SDKTextureSwapTool.PerformSwap(_swapCandidates);
+                            _swapCandidates = null;
+                        }
+                    }
+                    GUI.backgroundColor = Color.white;
+                    EditorGUI.EndDisabledGroup();
+                }
+            }
+
+            // Swap report
+            if (_swapReport != null)
+            {
+                EditorGUILayout.Space(3);
+
+                var reportMsg = $"Swap complete: {_swapReport.swapped} textures swapped.";
+                if (_swapReport.skippedMissingKtx2 > 0)
+                    reportMsg += $"\n{_swapReport.skippedMissingKtx2} skipped (no KTX2 file).";
+                if (_swapReport.skippedInAtlas > 0)
+                    reportMsg += $"\n{_swapReport.skippedInAtlas} skipped (in SpriteAtlas).";
+                if (_swapReport.skippedAlreadySwapped > 0)
+                    reportMsg += $"\n{_swapReport.skippedAlreadySwapped} skipped (already swapped).";
+
+                EditorGUILayout.HelpBox(reportMsg, MessageType.Info);
+            }
+        }
+
+        private void DrawKtx2Prerequisites()
+        {
+
+            EditorGUILayout.BeginHorizontal();
+            var packageIcon = _ktxPackageInstalled ? "●" : "○";
+            var packageColor = _ktxPackageInstalled ? "green" : "yellow";
+            var packageStyle = new GUIStyle(EditorStyles.label)
+            {
+                richText = true
+            };
+            EditorGUILayout.LabelField(
+                $"<color={packageColor}>{packageIcon}</color> com.unity.cloud.ktx: " +
+                (_ktxPackageInstalled ? "Installed" : "Not Installed"),
+                packageStyle);
+            if (!_ktxPackageInstalled)
+            {
+                if (GUILayout.Button("Install", GUILayout.Width(60)))
+                {
+                    Yes2SDKKtx2Tool.InstallKtxPackage();
+                    RefreshKtx2Status();
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.BeginHorizontal();
+            var toktxIcon = _toktxPath != null ? "●" : "○";
+            var toktxColor = _toktxPath != null ? "green" : "yellow";
+            var toktxStyle = new GUIStyle(EditorStyles.label) { richText = true };
+
+            if (_toktxPath != null)
+            {
+                EditorGUILayout.LabelField(
+                    $"<color={toktxColor}>{toktxIcon}</color> toktx: Found" +
+                    (!string.IsNullOrEmpty(_toktxVersion) ? $" ({_toktxVersion})" : ""),
+                    toktxStyle);
+            }
+            else
+            {
+                EditorGUILayout.LabelField(
+                    $"<color={toktxColor}>{toktxIcon}</color> toktx: Not Found",
+                    toktxStyle);
+
+                if (GUILayout.Button("Browse", GUILayout.Width(60)))
+                {
+                    var path = EditorUtility.OpenFilePanel("Locate toktx", "", "");
+                    if (!string.IsNullOrEmpty(path))
+                    {
+                        var version = Yes2SDKKtx2Tool.ValidateToktx(path);
+                        if (version != null)
+                        {
+                            Yes2SDKKtx2Tool.SaveToktxPath(path);
+                            _toktxPath = path;
+                            _toktxVersion = version;
+                        }
+                        else
+                        {
+                            EditorUtility.DisplayDialog("Yes2SDK",
+                                "The selected file is not a valid toktx executable.",
+                                "OK");
+                        }
+                    }
+                }
+                if (GUILayout.Button("Detect", GUILayout.Width(50)))
+                {
+                    RefreshKtx2Status();
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
+            if (_toktxPath == null)
+            {
+                EditorGUILayout.BeginHorizontal();
+                GUILayout.Space(15);
+                if (GUILayout.Button("Download KTX-Software", EditorStyles.linkLabel))
+                {
+                    Application.OpenURL(Yes2SDKKtx2Tool.KtxSoftwareReleasesUrl);
+                }
+                EditorGUILayout.EndHorizontal();
+            }
+        }
+
+        private static string FormatBytes(long bytes)
+        {
+            if (bytes < 1024) return $"{bytes} B";
+            if (bytes < 1024 * 1024) return $"{bytes / 1024f:F1} KB";
+            return $"{bytes / (1024f * 1024f):F1} MB";
         }
 
         private void DrawFooter()

--- a/README.md.meta
+++ b/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54a37f9db5e8e404584444efc0779360
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Ktx2.meta
+++ b/Runtime/Ktx2.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 901515d4fac3947ef84031bc6a02292e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Ktx2/Yes2SDK.Ktx2.asmdef
+++ b/Runtime/Ktx2/Yes2SDK.Ktx2.asmdef
@@ -1,8 +1,9 @@
 {
-    "name": "Yes2SDK.Runtime",
+    "name": "Yes2SDK.Ktx2",
     "rootNamespace": "Yes2SDK",
     "references": [
-        "Unity.Nuget.Newtonsoft-Json"
+        "Yes2SDK.Runtime",
+        "GUID:3d354272d3f2f4c3387dbccbaebd0f60"
     ],
     "includePlatforms": [
         "Editor",
@@ -13,7 +14,9 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
+    "defineConstraints": [
+        "YES2SDK_KTX"
+    ],
     "versionDefines": [
         {
             "name": "com.unity.cloud.ktx",

--- a/Runtime/Ktx2/Yes2SDK.Ktx2.asmdef.meta
+++ b/Runtime/Ktx2/Yes2SDK.Ktx2.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8b8e2d19567864b039424b1d87405279
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Ktx2/Yes2SDKKtx2Image.cs
+++ b/Runtime/Ktx2/Yes2SDKKtx2Image.cs
@@ -1,0 +1,114 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using KtxUnity;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Yes2SDK
+{
+    /// <summary>
+    /// Loads a KTX2 texture from StreamingAssets at runtime and assigns it to
+    /// the Image, RawImage, or SpriteRenderer on the same GameObject.
+    /// Requires com.unity.cloud.ktx package.
+    /// </summary>
+    [AddComponentMenu("Yes2SDK/KTX2 Image")]
+    public class Yes2SDKKtx2Image : MonoBehaviour
+    {
+        [Tooltip("Relative path inside StreamingAssets (e.g. ktx2/Textures/hero.ktx2)")]
+        [SerializeField] private string _ktx2Path;
+
+        [Tooltip("Enable for normal maps or linear-space textures")]
+        [SerializeField] private bool _linearColor;
+
+        /// <summary>
+        /// The KTX2 path relative to StreamingAssets.
+        /// </summary>
+        public string Ktx2Path
+        {
+            get => _ktx2Path;
+            set => _ktx2Path = value;
+        }
+
+        /// <summary>
+        /// Whether to load the texture in linear color space.
+        /// </summary>
+        public bool LinearColor
+        {
+            get => _linearColor;
+            set => _linearColor = value;
+        }
+
+        private void Start()
+        {
+            if (string.IsNullOrEmpty(_ktx2Path))
+            {
+                Debug.LogWarning($"[Yes2SDK]KTX2 path not set on {gameObject.name}");
+                return;
+            }
+
+            _ = LoadAsync();
+        }
+
+        private async Task LoadAsync()
+        {
+            try
+            {
+                var url = Path.Combine(Application.streamingAssetsPath, _ktx2Path);
+
+                var ktxTexture = new KtxTexture();
+                var result = await ktxTexture.LoadFromUrl(url);
+
+                if (result == null || result.texture == null)
+                {
+                    Debug.LogError($"[Yes2SDK]KTX2 load failed: {_ktx2Path}");
+                    return;
+                }
+
+                var texture = result.texture;
+                texture.wrapMode = TextureWrapMode.Clamp;
+
+                ApplyTexture(texture);
+
+                Debug.Log($"[Yes2SDK]KTX2 loaded: {_ktx2Path} ({texture.width}x{texture.height})");
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[Yes2SDK]KTX2 load error ({_ktx2Path}): {e.Message}");
+            }
+        }
+
+        private void ApplyTexture(Texture2D texture)
+        {
+            // Try RawImage first (most direct texture assignment)
+            var rawImage = GetComponent<RawImage>();
+            if (rawImage != null)
+            {
+                rawImage.texture = texture;
+                return;
+            }
+
+            // Try Image (needs Sprite wrapper)
+            var image = GetComponent<Image>();
+            if (image != null)
+            {
+                var rect = new Rect(0, 0, texture.width, texture.height);
+                var pivot = new Vector2(0.5f, 0.5f);
+                image.sprite = Sprite.Create(texture, rect, pivot);
+                return;
+            }
+
+            // Try SpriteRenderer
+            var spriteRenderer = GetComponent<SpriteRenderer>();
+            if (spriteRenderer != null)
+            {
+                var rect = new Rect(0, 0, texture.width, texture.height);
+                var pivot = new Vector2(0.5f, 0.5f);
+                spriteRenderer.sprite = Sprite.Create(texture, rect, pivot, 100f);
+                return;
+            }
+
+            Debug.LogWarning($"[Yes2SDK]No Image, RawImage, or SpriteRenderer found on {gameObject.name} for KTX2 texture");
+        }
+    }
+}

--- a/Runtime/Ktx2/Yes2SDKKtx2Image.cs.meta
+++ b/Runtime/Ktx2/Yes2SDKKtx2Image.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 91a9ca0170e5341569d4832c6cbd6c73

--- a/link.xml
+++ b/link.xml
@@ -3,6 +3,9 @@
     <!-- Preserve Yes2SDK types for IL2CPP -->
     <assembly fullname="Yes2SDK.Runtime" preserve="all"/>
 
+    <!-- Preserve KTX for IL2CPP (com.unity.cloud.ktx) -->
+    <assembly fullname="Ktx" preserve="all"/>
+
     <!-- Preserve Newtonsoft.Json for serialization -->
     <assembly fullname="Newtonsoft.Json" preserve="all">
         <type fullname="Newtonsoft.Json.JsonConvert" preserve="all"/>


### PR DESCRIPTION
## Summary #6 
- Add Sprite Atlas automation tool for scanning loose sprites and creating WebGL-optimized atlases
- Add KTX2 texture compression tool with runtime loader, KTX package integration, and IL2CPP support
- Add texture swap tool for replacing texture references with KTX2 runtime loaders
- Refactor editor window from single scrollable layout to three tabs: **Build**, **Optimization**, **Tools**

## Test plan
- [x] Open Yes2SDK > Settings — verify three tabs visible
- [x] **Build tab**: SDK Settings + Build Settings shown without foldouts, setup banner above tabs if needed
- [x] **Optimization tab**: Sprite Atlas and KTX2 sections with bold headers, content always visible
- [x] **Tools tab**: Coming soon placeholder buttons
- [x] Close and reopen window — verify selected tab persists
- [x] Verify Sprite Atlas scan/create workflow
- [x] Verify KTX2 prerequisite detection and conversion workflow
- [x] Verify texture swap scan/swap workflow