### PR TITLE
fix: prevent CrazyGames wrapper on non-CG platforms (v2.1.3)

### DIFF
--- a/Assets/WebGLTemplates/Yes2SDK-SuperSDK/index.html
+++ b/Assets/WebGLTemplates/Yes2SDK-SuperSDK/index.html
@@ -226,7 +226,7 @@
         // Store unity instance globally for SDK bridge access
         window.unityInstance = unityInstance;
       }).catch(function(message) {
-        alert(message);
+        console.error('[Yes2SDK] Unity instance error:', message);
       });
     };
     document.body.appendChild(script);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-04-13
+
+### Fixed
+- **WebGL template popup suppressed** — `createUnityInstance().catch()` in `Yes2SDK-SuperSDK/index.html` previously called `alert(message)` on any Unity runtime error. Now logs to `console.error` only — no popup ever reaches the player.
+
 ## [2.1.1] - 2026-04-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2026-04-14
+
+### Fixed
+- **CrazyGames wrapper wrongly created on GameDistribution** — `Yes2SDKPlatformInit.jslib` now checks `window.__yes2sdkConfig.platform` before creating the CG wrapper. GD and CrazyGames share Azerion infrastructure, so `window.CrazyGames.SDK` is present on `revision.gamedistribution.com`. Previously, if `yes2sdk.umd.js` was slow or blocked for any reason, the postset would replace the GD adapter with a CG wrapper. Now the postset exits immediately when the dashboard config specifies any platform other than `crazygames`.
+
 ## [2.1.2] - 2026-04-13
 
 ### Fixed

--- a/Plugins/Yes2SDKPlatformInit.jslib
+++ b/Plugins/Yes2SDKPlatformInit.jslib
@@ -29,7 +29,18 @@ mergeInto(LibraryManager.library, {
             window.__y2 = { log: m('log'), warn: m('warn'), error: m('error') };
         }
 
-        // Guard 2: not on CrazyGames — check multiple possible globals
+        // Guard 2: if yes2sdk-data.js config explicitly names a non-CG platform, never
+        // create a CG wrapper. GD/CrazyGames share Azerion infrastructure so
+        // window.CrazyGames.SDK can be present on revision.gamedistribution.com — without
+        // this guard, the postset would wrongly replace the GD SDK with a CG wrapper.
+        var cfgPlatform = window.__yes2sdkConfig && window.__yes2sdkConfig.platform;
+        if (cfgPlatform && cfgPlatform !== 'crazygames') {
+            window.__y2.log('PlatformInit: dashboard config says platform is "' + cfgPlatform +
+                '", skipping CG wrapper creation.');
+            return;
+        }
+
+        // Guard 3: not on CrazyGames — check multiple possible globals
         var hasCG = (typeof window.CrazyGames !== 'undefined' && window.CrazyGames.SDK);
         if (!hasCG) {
             window.__y2.log('PlatformInit: window.CrazyGames.SDK not found, skipping CG wrapper.',

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -66,7 +66,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.1.2";
+        public static string Version => "2.1.3";
 
         private static Yes2SDKAds _ads;
 

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -66,7 +66,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.1.1";
+        public static string Version => "2.1.2";
 
         private static Yes2SDKAds _ads;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline — build once, publish to 5 platforms",
     "unity": "2021.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline — build once, publish to 5 platforms",
     "unity": "2021.3",


### PR DESCRIPTION
## Summary

- **`Yes2SDKPlatformInit.jslib`** — postset now checks `window.__yes2sdkConfig.platform` before creating the CrazyGames wrapper. If the dashboard config explicitly names any platform other than `crazygames`, the postset exits immediately.
- **Root cause:** GD and CrazyGames are both owned by Azerion and share testing infrastructure. `window.CrazyGames.SDK` is present on `revision.gamedistribution.com`. When `yes2sdk.umd.js` was delayed or blocked for any reason, Guard 1 (`window.Yes2SDK` defined) would fail, Guard 2 (`window.CrazyGames.SDK` present) would pass, and the postset would replace the correct GD adapter with a full CrazyGames wrapper — causing the game to run as CrazyGames on GameDistribution.
- Bumps to **v2.1.3**.

## Test plan
- [ ] Build game with updated template, upload to dashboard, bundle for GameDistribution
- [ ] Test at `revision.gamedistribution.com` — console should show `PlatformInit: dashboard config says platform is "gamedistribution", skipping CG wrapper creation.`
- [ ] Verify CrazyGames still works normally when bundled for CrazyGames