### PR TITLE
docs(readme): address integrator feedback round 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # Yes2SDK for Unity
 
+[![Version](https://img.shields.io/github/v/tag/yes2games/yes2sdk-unity?label=version)](https://github.com/yes2games/yes2sdk-unity/releases)
+[![Unity](https://img.shields.io/badge/Unity-2021.3%2B-blue)](https://unity.com/)
+
 A single SDK for your Unity WebGL game. Integrate once against Yes2SDK, submit through the Yes2Games Dashboard, and the Yes2Games team handles the rest.
+
+The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string), so you can log it for support tickets.
 
 ## Requirements
 
-- Unity 2021.3 or newer
+- Unity 2021.3 or newer (Unity 6 supported — see [Building](#building))
 - WebGL build target
 - `com.unity.nuget.newtonsoft-json` (>= 3.2.1)
 
@@ -14,8 +19,10 @@ A single SDK for your Unity WebGL game. Integrate once against Yes2SDK, submit t
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter the repository URL for the Unity package
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.1.3`
 4. Click **Add**
+
+> Pinning the URL with `#v2.1.3` keeps the package hash stable across resolves. Bump the tag (e.g. `#v2.2.0`) to upgrade. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 
@@ -36,35 +43,53 @@ A single SDK for your Unity WebGL game. Integrate once against Yes2SDK, submit t
 
 ## Quick Start
 
-This is the **minimum integration** your game must have.
+This is the **minimum integration** your game must have. The lifecycle has three distinct stages — don't chain them together:
+
+```text
+App launch         → InitializeAsync   (SDK ready)
+Splash + loading   → SetLoadingProgress(0..100) as assets load
+Game playable      → StartGameAsync    (scene ready, accepting input)
+```
 
 ```csharp
+using System.Collections;
+using UnityEngine;
 using Yes2SDK;
 
 public class GameManager : MonoBehaviour
 {
     void Start()
     {
-        // 1. Initialize the SDK
-        Yes2SDK.Yes2SDK.InitializeAsync(
+        // Stage 1 — at app launch, initialize the SDK.
+        Yes2SDK.InitializeAsync(
             onSuccess: () =>
             {
                 Debug.Log("SDK ready");
-
-                // 2. Report loading progress as your assets load
-                Yes2SDK.Yes2SDK.SetLoadingProgress(100);
-
-                // 3. Tell the SDK the game is playable
-                Yes2SDK.Yes2SDK.StartGameAsync(
-                    onSuccess: () => Debug.Log("Game started"),
-                    onError: err => Debug.LogError(err)
-                );
+                StartCoroutine(LoadAndStart());
             },
+            onError: err => Debug.LogError(err)
+        );
+    }
+
+    IEnumerator LoadAndStart()
+    {
+        // Stage 2 — load your assets and report progress (0..100).
+        for (int p = 0; p <= 100; p += 10)
+        {
+            Yes2SDK.SetLoadingProgress(p);
+            yield return new WaitForSeconds(0.05f); // replace with real loading work
+        }
+
+        // Stage 3 — splash done, scene loaded, game is playable.
+        Yes2SDK.StartGameAsync(
+            onSuccess: () => Debug.Log("Game started"),
             onError: err => Debug.LogError(err)
         );
     }
 }
 ```
+
+> **Don't call `StartGameAsync` directly inside the `InitializeAsync` success handler.** The platform's loading bar treats `StartGameAsync` as "the game is playable now" — calling it before the player has anything to interact with shows a misleading 100% loading state.
 
 Without this flow your game won't be accepted for review.
 
@@ -78,53 +103,74 @@ Implement everything in this section. Together these cover what Yes2Games needs 
 
 ```csharp
 // Call once at startup
-Yes2SDK.Yes2SDK.InitializeAsync(onSuccess, onError);
+Yes2SDK.InitializeAsync(onSuccess, onError);
 
 // Call as your game loads (0-100)
-Yes2SDK.Yes2SDK.SetLoadingProgress(progress);
+Yes2SDK.SetLoadingProgress(progress);
 
 // Call when loading finishes and the game is playable
-Yes2SDK.Yes2SDK.StartGameAsync(onSuccess, onError);
+Yes2SDK.StartGameAsync(onSuccess, onError);
 ```
+
+> **Important:** these three calls fire in three distinct stages — *don't chain them*. `InitializeAsync` is at app launch. `SetLoadingProgress` is updated as your assets load. `StartGameAsync` runs **only when the game is actually playable** (splash gone, scene loaded, accepting input). See [Quick Start](#quick-start) for the full pattern.
 
 Handle pause / resume so your game reacts when the SDK pauses you (e.g. during an ad):
 
 ```csharp
-Yes2SDK.Yes2SDK.OnPause  += () => { Time.timeScale = 0; AudioListener.pause = true;  };
-Yes2SDK.Yes2SDK.OnResume += () => { Time.timeScale = 1; AudioListener.pause = false; };
+Yes2SDK.OnPause  += () => { Time.timeScale = 0; AudioListener.pause = true;  };
+Yes2SDK.OnResume += () => { Time.timeScale = 1; AudioListener.pause = false; };
 ```
 
 ### Ads (required)
 
 Interstitial ads run at natural break points. Rewarded ads run only when the player opts in.
 
+> **Always wrap ad calls in `Game.GameplayStop()` / `Game.GameplayStart()`.** Platforms count "active gameplay seconds" for monetization — leaving gameplay running during an ad inflates those numbers and is grounds for rejection. See [Gameplay Tracking](#gameplay-tracking-required) for the full rule.
+
 ```csharp
-Yes2SDK.Yes2SDK.Ads.ShowInterstitial(
+Yes2SDK.Game.GameplayStop();              // before the ad
+Yes2SDK.Ads.ShowInterstitial(
     placement: "level-end",
     description: "Between levels",
     beforeAd: () => PauseGame(),
-    afterAd:  () => ResumeGame(),
-    onError:  err => ResumeGame()   // always resume, even on error
+    afterAd:  () => { ResumeGame(); Yes2SDK.Game.GameplayStart(); },
+    onError:  err => { ResumeGame(); Yes2SDK.Game.GameplayStart(); }
 );
 
-Yes2SDK.Yes2SDK.Ads.ShowRewarded(
+Yes2SDK.Game.GameplayStop();              // before the ad
+Yes2SDK.Ads.ShowRewarded(
     placement: "extra-life",
     description: "Extra life reward",
     beforeAd:    () => PauseGame(),
-    afterAd:     () => ResumeGame(),
-    adDismissed: () => { /* no reward */ },
+    afterAd:     () => { ResumeGame(); Yes2SDK.Game.GameplayStart(); },
+    adDismissed: () => { /* no reward — see firing order below */ },
     adViewed:    () => GiveReward(),
-    onError:     err => ResumeGame()
+    onError:     err => { ResumeGame(); Yes2SDK.Game.GameplayStart(); }
 );
 ```
+
+#### Rewarded ad firing order
+
+The callbacks fire in this order. Pay attention — getting it wrong silently breaks reward logic:
+
+```text
+beforeAd      → pause game (always)
+(ad shown)
+afterAd       → resume game (always — fires whether the player watched or dismissed)
+adViewed      → grant reward (ONLY fires if the player watched the full ad)
+   — or —
+adDismissed   → no reward (fires if the player skipped/closed early)
+```
+
+> ⚠️ **Do NOT grant rewards in `afterAd`.** `afterAd` fires for both completion *and* dismissal — granting rewards there gives them away on skip. Always grant in `adViewed`.
 
 ### Gameplay Tracking (required)
 
 Tells Yes2Games when an active round begins and ends. Also call `GameplayStop()` before any ad and `GameplayStart()` after.
 
 ```csharp
-Yes2SDK.Yes2SDK.Game.GameplayStart();
-Yes2SDK.Yes2SDK.Game.GameplayStop();
+Yes2SDK.Game.GameplayStart();
+Yes2SDK.Game.GameplayStop();
 ```
 
 > `Analytics.LogLevelStart` / `LogLevelEnd` can also trigger gameplay start / stop — use either pair, but don't call both.
@@ -134,32 +180,32 @@ Yes2SDK.Yes2SDK.Game.GameplayStop();
 Key-value storage. Persists across sessions automatically.
 
 ```csharp
-Yes2SDK.Yes2SDK.Data.SetInt("highScore", 1500);
-Yes2SDK.Yes2SDK.Data.SetString("playerName", "Hero");
+Yes2SDK.Data.SetInt("highScore", 1500);
+Yes2SDK.Data.SetString("playerName", "Hero");
 
-int score = Yes2SDK.Yes2SDK.Data.GetInt("highScore", defaultValue: 0);
+int score = Yes2SDK.Data.GetInt("highScore", defaultValue: 0);
 
-bool exists = Yes2SDK.Yes2SDK.Data.HasKey("highScore");
-Yes2SDK.Yes2SDK.Data.DeleteKey("highScore");
+bool exists = Yes2SDK.Data.HasKey("highScore");
+Yes2SDK.Data.DeleteKey("highScore");
 ```
 
 ### Analytics (recommended)
 
 ```csharp
-Yes2SDK.Yes2SDK.Analytics.LogEvent("custom-event", new Dictionary<string, object> {
+Yes2SDK.Analytics.LogEvent("custom-event", new Dictionary<string, object> {
     { "key", "value" }
 });
 
-Yes2SDK.Yes2SDK.Analytics.LogLevelStart("level-1");
-Yes2SDK.Yes2SDK.Analytics.LogLevelEnd("level-1", score: 1500, success: true);
-Yes2SDK.Yes2SDK.Analytics.LogScore(1500);
+Yes2SDK.Analytics.LogLevelStart("level-1");
+Yes2SDK.Analytics.LogLevelEnd("level-1", score: 1500, success: true);
+Yes2SDK.Analytics.LogScore(1500);
 ```
 
 ### Session (recommended)
 
 ```csharp
-string locale = Yes2SDK.Yes2SDK.Session.GetLocale();  // e.g. "en", "fr"
-string device = Yes2SDK.Yes2SDK.Session.GetDevice();   // "desktop" or "mobile"
+string locale = Yes2SDK.Session.GetLocale();  // e.g. "en", "fr"
+string device = Yes2SDK.Session.GetDevice();   // "desktop" or "mobile"
 ```
 
 > Treat session info as a hint, not a guarantee. Don't branch your core game logic on it.
@@ -168,19 +214,19 @@ string device = Yes2SDK.Yes2SDK.Session.GetDevice();   // "desktop" or "mobile"
 
 ## Optional APIs
 
-These modules add extra player-facing features. They are **not guaranteed** to be available at runtime — always guard with `IsSupported()` and handle `FeatureNotSupported` gracefully. Don't make your core gameplay depend on them.
+These modules add extra player-facing features. They are **not guaranteed** to be available at runtime — guard with `IsSupported()` where the module exposes it (currently `Auth` and `Player`), and always handle `FeatureNotSupported` errors gracefully. Don't make your core gameplay depend on them.
 
 ### Auth
 
 ```csharp
-if (Yes2SDK.Yes2SDK.Auth.IsSupported())
+if (Yes2SDK.Auth.IsSupported())
 {
-    Yes2SDK.Yes2SDK.Auth.GetCurrentUserAsync(
+    Yes2SDK.Auth.GetCurrentUserAsync(
         onSuccess: user => Debug.Log($"User: {user.Name}, authenticated: {user.IsAuthenticated}"),
         onError:   err  => Debug.LogError(err)
     );
 
-    Yes2SDK.Yes2SDK.Auth.SignInAsync(
+    Yes2SDK.Auth.SignInAsync(
         onSuccess: user => Debug.Log($"Signed in as {user.Name}"),
         onError:   err  => Debug.LogError(err)
     );
@@ -189,14 +235,21 @@ if (Yes2SDK.Yes2SDK.Auth.IsSupported())
 
 ### Friends
 
+`Friends` does not yet expose `IsSupported()` — handle the `FeatureNotSupported` error instead, and hide friends UI on platforms that reject the call.
+
 ```csharp
-Yes2SDK.Yes2SDK.Friends.ListFriendsAsync(
+Yes2SDK.Friends.ListFriendsAsync(
     page: 0, size: 10,
     onSuccess: page => {
         foreach (var friend in page.Friends)
             Debug.Log($"{friend.Username} ({friend.Id})");
     },
-    onError: err => Debug.LogError(err)
+    onError: err => {
+        if (err.ErrorCode == ErrorCode.FeatureNotSupported)
+            HideFriendsUI();          // platform doesn't support friends
+        else
+            Debug.LogError(err);
+    }
 );
 ```
 
@@ -205,50 +258,52 @@ Yes2SDK.Yes2SDK.Friends.ListFriendsAsync(
 Container-based display ads. Different from `Ads.ShowBanner`.
 
 ```csharp
-Yes2SDK.Yes2SDK.Banners.ShowBanner("sidebar-left", BannerSize.Medium_300x250);
-Yes2SDK.Yes2SDK.Banners.HideBanner("sidebar-left");
-Yes2SDK.Yes2SDK.Banners.HideAllBanners();
+Yes2SDK.Banners.ShowBanner("sidebar-left", BannerSize.Medium_300x250);
+Yes2SDK.Banners.HideBanner("sidebar-left");
+Yes2SDK.Banners.HideAllBanners();
 ```
 
 ### Game Extras
 
-```csharp
-Yes2SDK.Yes2SDK.Game.HappyTime();
+`HappyTime()` signals to the platform that the player just hit a positive moment — level cleared, achievement unlocked, boss defeated. Some platforms use this signal to time monetization prompts and rate requests so they don't interrupt frustrating moments. Call it sparingly, only on genuine highs.
 
-Yes2SDK.Yes2SDK.Game.InviteLinkAsync(
+```csharp
+Yes2SDK.Game.HappyTime();
+
+Yes2SDK.Game.InviteLinkAsync(
     new Dictionary<string, string> { { "roomId", "abc123" } },
     onSuccess: link => Debug.Log($"Invite: {link}")
 );
 
-Yes2SDK.Yes2SDK.Game.ShowInviteButton(new Dictionary<string, string> { { "roomId", "abc123" } });
-Yes2SDK.Yes2SDK.Game.HideInviteButton();
+Yes2SDK.Game.ShowInviteButton(new Dictionary<string, string> { { "roomId", "abc123" } });
+Yes2SDK.Game.HideInviteButton();
 
-GameSettings settings = Yes2SDK.Yes2SDK.Game.GetSettings();
-Yes2SDK.Yes2SDK.Game.OnSettingsChanged += s => ApplySettings(s);
+GameSettings settings = Yes2SDK.Game.GetSettings();
+Yes2SDK.Game.OnSettingsChanged += s => ApplySettings(s);
 
-Yes2SDK.Yes2SDK.Game.CopyToClipboard("https://...");
+Yes2SDK.Game.CopyToClipboard("https://...");
 ```
 
 ### Score
 
 ```csharp
-Yes2SDK.Yes2SDK.Score.AddScore(150f);
-Yes2SDK.Yes2SDK.Score.SubmitScore("encrypted-score-string");
+Yes2SDK.Score.AddScore(150f);
+Yes2SDK.Score.SubmitScore("encrypted-score-string");
 ```
 
 ### Player Data
 
 ```csharp
-if (Yes2SDK.Yes2SDK.Player.IsDataSupported())
+if (Yes2SDK.Player.IsDataSupported())
 {
-    Yes2SDK.Yes2SDK.Player.SetDataAsync("{\"level\":5}", onSuccess: () => {});
-    Yes2SDK.Yes2SDK.Player.GetDataAsync(new[] { "level" }, onSuccess: json => {});
-    Yes2SDK.Yes2SDK.Player.FlushDataAsync();
+    Yes2SDK.Player.SetDataAsync("{\"level\":5}", onSuccess: () => {});
+    Yes2SDK.Player.GetDataAsync(new[] { "level" }, onSuccess: json => {});
+    Yes2SDK.Player.FlushDataAsync();
 }
 
-if (Yes2SDK.Yes2SDK.Player.IsConnectedPlayersSupported())
+if (Yes2SDK.Player.IsConnectedPlayersSupported())
 {
-    Yes2SDK.Yes2SDK.Player.GetConnectedPlayersAsync(onSuccess: json => {});
+    Yes2SDK.Player.GetConnectedPlayersAsync(onSuccess: json => {});
 }
 ```
 
@@ -289,6 +344,13 @@ The QA Inspector in the Yes2Games Dashboard validates all of this automatically.
 | Compression | Disabled |
 | Code Stripping | Medium |
 | Exception Support | None |
+
+#### Where to set these — depends on your Unity version
+
+- **Unity 2021–2022**: *Edit > Project Settings > Player > WebGL* (project-wide).
+- **Unity 6+**: *File > Build Profiles* — select your WebGL profile, then click **Player Settings** at the bottom of the profile panel. Settings apply only to that profile, so make sure the profile you build is the one with these values.
+
+> Unity 6 moved WebGL settings from project-wide Player Settings into per-profile Build Profiles. If you set values in the old location on Unity 6+, the build will pick up the *profile's* defaults instead and your settings are silently ignored.
 
 ---
 
@@ -335,6 +397,19 @@ onError: err => {
         Debug.LogError(err);
 }
 ```
+
+### Error code reference
+
+| Code | When it fires | Recommended handling |
+|------|---------------|----------------------|
+| `NotInitialized` | An API was called before `InitializeAsync` succeeded. | Wait for init to complete first; never call SDK methods from `Awake()` without checking `Yes2SDK.IsInitialized`. |
+| `InvalidParams` | A required parameter was null/empty or out of range. | Treat as a programmer error — fix the call site. |
+| `FeatureNotSupported` | The optional API isn't available on this platform (e.g. Friends on Poki). | Hide the related UI; fall back to a non-platform alternative. Always pre-check with `IsSupported()` for optional APIs. |
+| `PlatformError` | The underlying platform SDK rejected the call. | Log `err.Message` and `err.Context` for support; treat the call as failed. |
+| `NetworkError` | A platform call failed network-side (timeout, offline, server error). | Retry with backoff. Don't retry indefinitely. |
+| `RateLimited` | Too many calls in a short window (e.g. ad spam protection). | Back off and try again later — don't retry immediately. |
+| `UserCancelled` | The player closed/dismissed a flow (e.g. login dialog, rewarded ad). | Not an error in the usual sense — silently respect the player's choice, no toast. |
+| `Unknown` | The error didn't match any of the above. | Log everything (`err.Code`, `err.Message`, `err.Context`) and treat as a hard failure. |
 
 ---
 


### PR DESCRIPTION
## Summary
README rewrite addressing the doc-shaped feedback from Dhani and Atqa (NSR Street integration, Unity 6000.3.9f1).

This is **README-only** — no plugin code touched, no version bump, no tag needed. Closes 11 issues. The remaining 7 (#17, #18, #22, #26, #27, #28, #29, #30) need code changes and will land in a separate `feat/round-2-code-fixes-2.2.0` branch.

## Closes
- #16 — Ad callback firing order is now explicitly documented with a labeled order block + "do NOT grant rewards in afterAd" warning.
- #19 — Installation now provides the concrete Git URL `https://github.com/yes2games/yes2sdk-unity.git#v2.1.3` with a tag-pin explanation.
- #20 — Quick Start rewritten as a three-stage coroutine; no more synchronous `SetLoadingProgress(100)` chained inside `InitializeAsync.onSuccess`.
- #21 — Mixed style cleanup: every `Yes2SDK.Yes2SDK.X` collapsed to `Yes2SDK.X` (relies on `using Yes2SDK;`).
- #23 — `Game.HappyTime()` now has a one-paragraph explanation.
- #24 — Ads section cross-references `GameplayStop`/`GameplayStart` and shows them inline in the example.
- #25 — Version badge + note about runtime-accessible `Yes2SDK.Version`.
- #31 — Lifecycle section adds an explicit "don't chain them" ordering callout.
- #32 — Building gained a Unity 6 Build Profiles sub-section since the old Player Settings location no longer applies in Unity 6+.

## Partially addresses
- #22 — Friends sample is now honest: it documents that `IsSupported()` is not yet exposed on Friends and shows the proper `FeatureNotSupported` error-handling pattern. The proper fix (adding `IsSupported()` to all optional modules) remains tracked in #22 and will land with the round-2 code PR.
- #33 — Error code reference table added. Multi-SDK coexistence guide and init `CancellationToken`/timeout discussion remain open under #33.