### PR TITLE
feat(editor): fail WebGL builds early when SuperSDK template is missing

### DIFF
--- a/Editor/Yes2SDKBuildGuard.cs
+++ b/Editor/Yes2SDKBuildGuard.cs
@@ -1,0 +1,42 @@
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// Fails WebGL builds early when the Yes2SDK-SuperSDK template is missing or
+    /// not selected in PlayerSettings. Without this guard, Unity silently falls
+    /// back to its default WebGL template — the build "succeeds" but the JS
+    /// bridge is never wired up, shipping a broken game.
+    /// </summary>
+    public class Yes2SDKBuildGuard : IPreprocessBuildWithReport
+    {
+        private const string ExpectedTemplate = "PROJECT:Yes2SDK-SuperSDK";
+
+        public int callbackOrder => 0;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            if (report.summary.platform != BuildTarget.WebGL) return;
+
+            if (!Yes2SDKInstaller.IsSetupComplete())
+            {
+                throw new BuildFailedException(
+                    "[Yes2SDK] WebGL template is not installed. " +
+                    "Open Yes2SDK > Build Window and click Install Template, " +
+                    "then rebuild.");
+            }
+
+            if (PlayerSettings.WebGL.template != ExpectedTemplate)
+            {
+                throw new BuildFailedException(
+                    $"[Yes2SDK] PlayerSettings WebGL template is '{PlayerSettings.WebGL.template}', " +
+                    $"expected '{ExpectedTemplate}'. " +
+                    "Open Yes2SDK > Build Window and click Apply Settings, " +
+                    "or set the template manually in Project Settings > Player > WebGL " +
+                    "(Unity 6+: in your Build Profile's Player Settings).");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a build pre-processor (`IPreprocessBuildWithReport`) that fails WebGL builds with an actionable error when the Yes2SDK-SuperSDK template is missing or not selected in PlayerSettings.

## Why
Atqa's CI runner (NSR Street, Unity 6) hit this exact silent failure: build "succeeds" against Unity's default WebGL template, JS bridge is never wired up, game ships broken. This guard catches it before the build runs.

The guard checks two things, both before any WebGL build:
1. `Yes2SDK-SuperSDK` template is installed under `Assets/WebGLTemplates/`.
2. `PlayerSettings.WebGL.template == "PROJECT:Yes2SDK-SuperSDK"`.

Either failure throws `BuildFailedException` with a message pointing the user at the fix (Yes2SDK > Build Window > Install Template / Apply Settings). Non-WebGL builds are unaffected.

## Closes
- #18

## Test plan
- [x] WebGL build with template installed and selected → succeeds.
- [x] WebGL build with template missing → fails with the install-template error.
- [x] WebGL build with template installed but PlayerSettings pointing elsewhere → fails with the apply-settings error.
- [x] Build for any non-WebGL target → guard does not run.