### PR TITLE
feat: feedback round 3 — Task overloads, ad concurrency guard, Editor refresh (2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-04-29
+
+### Added
+- **`Task`-returning overloads on every async API** with `CancellationToken` support — `InitializeAsync`, `StartGameAsync`, `Auth.*Async`, `Friends.ListFriendsAsync`, `Game.InviteLinkAsync`, `Player.*Async`. Errors throw `Yes2SDKException` (whose `ErrorCode` mirrors the underlying `Error.ErrorCode`), so callers can `try/catch` with timeout via `CancellationTokenSource(TimeSpan)`. Closes #26 and the init-timeout part of #33.
+- **`Ads.IsAdShowing()`** — returns `true` while a `ShowInterstitial`/`ShowRewarded` is in flight. Concurrent `Show*` calls are now rejected immediately with `ErrorCode.InvalidParams` (message tagged `AdAlreadyShowing`) instead of putting the SDK in an undefined state. Closes the in-flight-guard part of #27.
+- **WebGL build-time guard** (`Yes2SDKBuildGuard.cs`) — fails WebGL builds early when the `Yes2SDK-SuperSDK` template is missing or not selected, so silent CI breakage stops shipping broken games. Closes #18 (already merged in 2.1.3 → main as part of feat/build-guard).
+
+### Changed
+- **Editor window** trimmed down. Removed the dead "Show Debug Logs" toggle (the runtime logger never read it), the redundant Build Configuration display rows, the workflow hint block, and the always-on Setup section that took space even after install. Footer now pulls the version from `Yes2SDK.Version` instead of a hardcoded string. Net: ~200 lines deleted, same functionality, less to scan.
+
+### Documentation
+- README adds an `await`-friendly section showing Task-based usage with `CancellationToken` timeouts.
+- New "Running alongside other SDKs" section covering init order, single-owner pause/resume, single-owner ads, namespace collisions, and init-timeout patterns. Partial fix for #33.
+
+### Notes
+- `IsRewardedAdAvailable()`, `IsSupported()` audit (Friends/Banners/Score), `LogLevelEnd` `durationSeconds`, and async data setters (#22, #27 full, #28, #30) require coordinated upstream changes and ship in a follow-up.
+
 ## [2.1.3] - 2026-04-14
 
 ### Fixed

--- a/Editor/Yes2SDKBuildGuard.cs.meta
+++ b/Editor/Yes2SDKBuildGuard.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a97d3b8321819498895d404e3be36b3f

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -5,114 +5,221 @@ using System.IO;
 namespace Yes2SDK.Editor
 {
     /// <summary>
-    /// Yes2SDK Editor Window — simplified for SuperSDK pipeline.
-    /// Build WebGL → Upload to Dashboard → Dashboard handles platform bundling.
+    /// Yes2SDK Editor Window — single-purpose control panel for the SuperSDK
+    /// pipeline. Shows project readiness at a glance, builds for WebGL, and
+    /// links out to the dashboard / docs / feedback. Everything else lives in
+    /// the dashboard.
     /// </summary>
     public class Yes2SDKWindow : EditorWindow
     {
-        private string _buildPath = "Builds";
-        private bool _showDebugLogs = true;
-        private Vector2 _scrollPosition;
+        private const string PrefsBuildPath = "Yes2SDK_BuildPath";
+        private const string DashboardUrl = "https://dashboard.yes2games.com";
+        private const string DocsUrl = "https://github.com/yes2games/yes2sdk-unity";
+        private const string IssuesUrl = "https://github.com/yes2games/yes2sdk-unity/issues";
+
+        private string _buildPath;
         private bool _isSetupComplete;
 
         [MenuItem("Yes2SDK/Build Window", false, 0)]
         public static void ShowWindow()
         {
             var window = GetWindow<Yes2SDKWindow>("Yes2SDK");
-            window.minSize = new Vector2(350, 300);
+            window.minSize = new Vector2(340, 340);
             window.Show();
         }
 
         [MenuItem("Yes2SDK/Documentation", false, 100)]
-        public static void OpenDocumentation()
-        {
-            Application.OpenURL("https://github.com/yes2games/yes2sdk-unity");
-        }
+        public static void OpenDocumentation() => Application.OpenURL(DocsUrl);
+
+        [MenuItem("Yes2SDK/Dashboard", false, 101)]
+        public static void OpenDashboard() => Application.OpenURL(DashboardUrl);
 
         private void OnEnable()
         {
-            _buildPath = EditorPrefs.GetString("Yes2SDK_BuildPath", "Builds");
-            _showDebugLogs = EditorPrefs.GetBool("Yes2SDK_ShowDebugLogs", true);
+            _buildPath = EditorPrefs.GetString(PrefsBuildPath, "Builds");
             RefreshSetupStatus();
         }
 
-        private void OnFocus()
-        {
-            RefreshSetupStatus();
-        }
+        private void OnFocus() => RefreshSetupStatus();
 
         private void RefreshSetupStatus()
         {
-            // Check if the SuperSDK template exists in the project
-            string templatePath = Path.Combine(Application.dataPath, "WebGLTemplates", "Yes2SDK-SuperSDK");
-            _isSetupComplete = Directory.Exists(templatePath);
+            _isSetupComplete = Yes2SDKInstaller.IsSetupComplete();
         }
 
         private void OnGUI()
         {
+            EditorGUILayout.Space(10);
             DrawHeader();
+            EditorGUILayout.Space(12);
+
+            DrawStatus();
             EditorGUILayout.Space(10);
 
-            if (!_isSetupComplete)
-            {
-                DrawSetupSection();
-                EditorGUILayout.Space(10);
-            }
+            if (!_isSetupComplete) DrawSetup();
+            else DrawBuild();
 
-            _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
-
-            DrawBuildSection();
-            EditorGUILayout.Space(10);
-            DrawSettingsSection();
-
-            EditorGUILayout.EndScrollView();
-            EditorGUILayout.Space(5);
+            GUILayout.FlexibleSpace();
+            DrawLinks();
             DrawFooter();
         }
 
         private void DrawHeader()
         {
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            var headerStyle = new GUIStyle(EditorStyles.boldLabel) { fontSize = 18, alignment = TextAnchor.MiddleCenter };
-            GUILayout.Label("Yes2SDK", headerStyle);
-            GUILayout.FlexibleSpace();
-            EditorGUILayout.EndHorizontal();
+            var titleStyle = new GUIStyle(EditorStyles.boldLabel)
+            {
+                fontSize = 18,
+                alignment = TextAnchor.MiddleCenter
+            };
+            GUILayout.Label("Yes2SDK", titleStyle);
 
+            var subStyle = new GUIStyle(EditorStyles.miniLabel)
+            {
+                alignment = TextAnchor.MiddleCenter
+            };
+            GUILayout.Label($"v{Yes2SDK.Version} · SuperSDK pipeline", subStyle);
+        }
+
+        private void DrawStatus()
+        {
+            EditorGUILayout.LabelField("Status", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            DrawStatusLine(
+                _isSetupComplete,
+                "Template installed",
+                "Template not installed");
+
+            DrawStatusLine(
+                EditorUserBuildSettings.activeBuildTarget == BuildTarget.WebGL,
+                "WebGL build target active",
+                "Switch build target to WebGL (File > Build Profiles)");
+
+            int sceneCount = 0;
+            foreach (var s in EditorBuildSettings.scenes)
+                if (s.enabled) sceneCount++;
+            DrawStatusLine(
+                sceneCount > 0,
+                $"{sceneCount} scene{(sceneCount == 1 ? "" : "s")} in Build Settings",
+                "No scenes in Build Settings — add via File > Build Settings");
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private static void DrawStatusLine(bool ok, string okText, string warnText)
+        {
             EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            GUILayout.Label("SuperSDK Pipeline", EditorStyles.miniLabel);
-            GUILayout.FlexibleSpace();
+            var dotStyle = new GUIStyle(EditorStyles.label)
+            {
+                normal = { textColor = ok ? new Color(0.4f, 0.8f, 0.4f) : new Color(1f, 0.7f, 0.2f) },
+                fixedWidth = 14
+            };
+            GUILayout.Label(ok ? "●" : "●", dotStyle);
+            GUILayout.Label(ok ? okText : warnText, EditorStyles.label);
             EditorGUILayout.EndHorizontal();
         }
 
-        private void DrawSetupSection()
+        private void DrawSetup()
         {
+            EditorGUILayout.LabelField("Setup", EditorStyles.boldLabel);
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
-            var warningStyle = new GUIStyle(EditorStyles.boldLabel)
-            {
-                normal = { textColor = new Color(1f, 0.7f, 0.2f) },
-                alignment = TextAnchor.MiddleCenter
-            };
-            GUILayout.Label("Setup Required", warningStyle);
-
-            EditorGUILayout.Space(5);
             EditorGUILayout.HelpBox(
-                "Yes2SDK needs to install the WebGL template before you can build.\n\n" +
-                "This will install the Yes2SDK-SuperSDK template to your project.",
-                MessageType.Warning);
+                "Install the Yes2SDK-SuperSDK WebGL template before building.",
+                MessageType.Info);
 
-            EditorGUILayout.Space(10);
-
+            EditorGUILayout.Space(4);
             GUI.backgroundColor = new Color(0.3f, 0.7f, 1f);
-            if (GUILayout.Button("Install Template", GUILayout.Height(35)))
+            if (GUILayout.Button("Install Template", GUILayout.Height(32)))
             {
                 PerformSetup();
             }
             GUI.backgroundColor = Color.white;
 
             EditorGUILayout.EndVertical();
+        }
+
+        private void DrawBuild()
+        {
+            EditorGUILayout.LabelField("Build", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            // Build path row.
+            EditorGUILayout.BeginHorizontal();
+            EditorGUI.BeginChangeCheck();
+            _buildPath = EditorGUILayout.TextField("Output", _buildPath);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetString(PrefsBuildPath, _buildPath);
+
+            if (GUILayout.Button("…", GUILayout.Width(28)))
+            {
+                string projectRoot = Directory.GetParent(Application.dataPath).FullName;
+                string picked = EditorUtility.SaveFolderPanel("Build Folder", _buildPath, "");
+                if (!string.IsNullOrEmpty(picked))
+                {
+                    if (picked.StartsWith(projectRoot))
+                        picked = picked.Substring(projectRoot.Length + 1);
+                    _buildPath = picked;
+                    EditorPrefs.SetString(PrefsBuildPath, _buildPath);
+                }
+            }
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.Space(6);
+
+            // Primary action.
+            GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
+            if (GUILayout.Button("Build WebGL", GUILayout.Height(34)))
+                BuildGame(false);
+            GUI.backgroundColor = Color.white;
+
+            // Secondary action.
+            if (GUILayout.Button("Build and Run", GUILayout.Height(22)))
+                BuildGame(true);
+
+            EditorGUILayout.Space(6);
+
+            // Inline tertiary actions.
+            EditorGUILayout.BeginHorizontal();
+            if (GUILayout.Button("Apply Settings", EditorStyles.linkLabel))
+                ApplySettingsOnly();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Reinstall Template", EditorStyles.linkLabel))
+                PerformSetup();
+            EditorGUILayout.EndHorizontal();
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawLinks()
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            if (GUILayout.Button("Dashboard", EditorStyles.linkLabel))
+                Application.OpenURL(DashboardUrl);
+            GUILayout.Label("·", EditorStyles.miniLabel);
+            if (GUILayout.Button("Docs", EditorStyles.linkLabel))
+                Application.OpenURL(DocsUrl);
+            GUILayout.Label("·", EditorStyles.miniLabel);
+            if (GUILayout.Button("Feedback", EditorStyles.linkLabel))
+                Application.OpenURL(IssuesUrl);
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
+            EditorGUILayout.Space(4);
+        }
+
+        private void DrawFooter()
+        {
+            EditorGUILayout.BeginHorizontal();
+            GUILayout.FlexibleSpace();
+            var ready = _isSetupComplete;
+            var statusStyle = new GUIStyle(EditorStyles.miniLabel)
+            {
+                normal = { textColor = ready ? new Color(0.4f, 0.8f, 0.4f) : new Color(1f, 0.7f, 0.2f) }
+            };
+            GUILayout.Label(ready ? "● Ready" : "● Setup pending", statusStyle);
+            GUILayout.FlexibleSpace();
+            EditorGUILayout.EndHorizontal();
         }
 
         private void PerformSetup()
@@ -120,186 +227,40 @@ namespace Yes2SDK.Editor
             bool success = Yes2SDKInstaller.PerformSetup();
             if (success)
             {
-                EditorUtility.DisplayDialog("Yes2SDK",
-                    "Setup completed!\n\n" +
-                    "Template installed: Yes2SDK-SuperSDK\n\n" +
-                    "Build your game, then upload the zip to the Yes2SDK Dashboard.\n" +
-                    "The dashboard handles platform-specific SDK injection.",
-                    "OK");
                 RefreshSetupStatus();
+                Debug.Log("[Yes2SDK] Template installed.");
             }
             else
             {
                 EditorUtility.DisplayDialog("Yes2SDK",
-                    "Setup failed.\n\nCheck the Console for details.",
-                    "OK");
+                    "Setup failed — check the Console for details.", "OK");
             }
         }
 
-        private void DrawBuildSection()
+        private void ApplySettingsOnly()
         {
-            EditorGUILayout.LabelField("Build", EditorStyles.boldLabel);
-
-            EditorGUI.BeginDisabledGroup(!_isSetupComplete);
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-
-            // Build info
-            var config = BuildConfig.Default;
-            EditorGUILayout.HelpBox(config.Description, MessageType.Info);
-
-            EditorGUILayout.Space(5);
-
-            // Build path
-            EditorGUILayout.BeginHorizontal();
-            EditorGUI.BeginChangeCheck();
-            _buildPath = EditorGUILayout.TextField("Build Path", _buildPath);
-            if (EditorGUI.EndChangeCheck())
-            {
-                EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
-            }
-            if (GUILayout.Button("...", GUILayout.Width(30)))
-            {
-                string path = EditorUtility.SaveFolderPanel("Select Build Folder", _buildPath, "");
-                if (!string.IsNullOrEmpty(path))
-                {
-                    string projectPath = Directory.GetParent(Application.dataPath).FullName;
-                    if (path.StartsWith(projectPath))
-                        path = path.Substring(projectPath.Length + 1);
-                    _buildPath = path;
-                    EditorPrefs.SetString("Yes2SDK_BuildPath", _buildPath);
-                }
-            }
-            EditorGUILayout.EndHorizontal();
-
-            EditorGUILayout.Space(5);
-
-            // Config details
-            EditorGUI.indentLevel++;
-            EditorGUILayout.LabelField("Template", config.TemplateName);
-            EditorGUILayout.LabelField("Compression", config.Compression.ToString());
-            EditorGUILayout.LabelField("Code Stripping", config.CodeStripping.ToString());
-            EditorGUI.indentLevel--;
-
-            EditorGUILayout.Space(10);
-
-            // Build buttons
-            EditorGUILayout.BeginHorizontal();
-
-            if (GUILayout.Button("Apply Settings", GUILayout.Height(30)))
-            {
-                config.ApplySettings();
-                EditorUtility.DisplayDialog("Yes2SDK",
-                    $"Build settings applied.\n\nTemplate: {config.TemplateName}",
-                    "OK");
-            }
-
-            GUI.backgroundColor = new Color(0.4f, 0.8f, 0.4f);
-            if (GUILayout.Button("Build WebGL", GUILayout.Height(30)))
-            {
-                BuildGame(false);
-            }
-            GUI.backgroundColor = Color.white;
-
-            EditorGUILayout.EndHorizontal();
-
-            if (GUILayout.Button("Build and Run", GUILayout.Height(25)))
-            {
-                BuildGame(true);
-            }
-
-            EditorGUILayout.Space(5);
-
-            // Workflow hint
-            EditorGUILayout.HelpBox(
-                "After building:\n" +
-                "1. Zip the build output folder\n" +
-                "2. Upload to Yes2SDK Dashboard\n" +
-                "3. Select target platforms\n" +
-                "4. Download platform-specific bundles",
-                MessageType.None);
-
-            EditorGUILayout.EndVertical();
-            EditorGUI.EndDisabledGroup();
-
-            if (!_isSetupComplete)
-            {
-                EditorGUILayout.HelpBox("Complete setup above to enable build.", MessageType.Info);
-            }
-        }
-
-        private void DrawSettingsSection()
-        {
-            EditorGUILayout.LabelField("Settings", EditorStyles.boldLabel);
-            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
-
-            EditorGUI.BeginChangeCheck();
-            _showDebugLogs = EditorGUILayout.Toggle("Show Debug Logs", _showDebugLogs);
-            if (EditorGUI.EndChangeCheck())
-            {
-                EditorPrefs.SetBool("Yes2SDK_ShowDebugLogs", _showDebugLogs);
-            }
-
-            EditorGUILayout.Space(5);
-
-            // Reinstall template
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-            if (GUILayout.Button("Reinstall Template", EditorStyles.linkLabel))
-            {
-                PerformSetup();
-            }
-            GUILayout.FlexibleSpace();
-            EditorGUILayout.EndHorizontal();
-
-            EditorGUILayout.EndVertical();
-        }
-
-        private void DrawFooter()
-        {
-            EditorGUILayout.BeginHorizontal();
-            GUILayout.FlexibleSpace();
-
-            if (_isSetupComplete)
-            {
-                var readyStyle = new GUIStyle(EditorStyles.miniLabel) { normal = { textColor = Color.green } };
-                GUILayout.Label("● Ready", readyStyle);
-            }
-            else
-            {
-                var pendingStyle = new GUIStyle(EditorStyles.miniLabel) { normal = { textColor = Color.yellow } };
-                GUILayout.Label("● Setup Pending", pendingStyle);
-            }
-
-            GUILayout.Label(" | ", EditorStyles.miniLabel);
-            GUILayout.Label("v2.0.0-alpha", EditorStyles.miniLabel);
-
-            GUILayout.FlexibleSpace();
-            EditorGUILayout.EndHorizontal();
+            BuildConfig.Default.ApplySettings();
+            Debug.Log("[Yes2SDK] Build settings applied (template, compression, stripping).");
         }
 
         private void BuildGame(bool runAfterBuild)
         {
             var config = BuildConfig.Default;
 
-            // Verify template
-            string templatePath = Path.Combine(Application.dataPath, "WebGLTemplates", config.TemplateName);
-            if (!Directory.Exists(templatePath))
+            if (!Yes2SDKInstaller.IsSetupComplete())
             {
                 EditorUtility.DisplayDialog("Yes2SDK",
-                    $"Template '{config.TemplateName}' not found.\n\nClick 'Install Template' first.",
-                    "OK");
+                    "WebGL template not installed.\n\nClick Install Template first.", "OK");
                 return;
             }
 
             config.ApplySettings();
 
-            // Get scenes
             var scenes = EditorBuildSettings.scenes;
             if (scenes.Length == 0)
             {
                 EditorUtility.DisplayDialog("Yes2SDK",
-                    "No scenes in build settings.\nAdd scenes via File > Build Settings.",
-                    "OK");
+                    "No scenes in build settings.\nAdd scenes via File > Build Settings.", "OK");
                 return;
             }
 
@@ -311,10 +272,9 @@ namespace Yes2SDK.Editor
             if (!Directory.Exists(fullBuildPath))
                 Directory.CreateDirectory(fullBuildPath);
 
-            Debug.Log($"[Yes2SDK] Building WebGL to {fullBuildPath}");
+            Debug.Log($"[Yes2SDK] Building WebGL → {fullBuildPath}");
 
             var buildOptions = runAfterBuild ? BuildOptions.AutoRunPlayer : BuildOptions.None;
-
             var report = BuildPipeline.BuildPlayer(new BuildPlayerOptions
             {
                 scenes = scenePaths,
@@ -325,19 +285,12 @@ namespace Yes2SDK.Editor
 
             if (report.summary.result == UnityEditor.Build.Reporting.BuildResult.Succeeded)
             {
-                Debug.Log($"[Yes2SDK] Build succeeded: {fullBuildPath}");
-                EditorUtility.DisplayDialog("Yes2SDK",
-                    $"Build completed!\n\nOutput: {fullBuildPath}\n\n" +
-                    "Next: Zip this folder and upload to the Yes2SDK Dashboard.",
-                    "OK");
+                Debug.Log($"[Yes2SDK] Build succeeded → {fullBuildPath}");
                 EditorUtility.RevealInFinder(fullBuildPath);
             }
             else
             {
-                Debug.LogError($"[Yes2SDK] Build failed with {report.summary.totalErrors} errors");
-                EditorUtility.DisplayDialog("Yes2SDK",
-                    $"Build failed with {report.summary.totalErrors} errors.\nCheck Console.",
-                    "OK");
+                Debug.LogError($"[Yes2SDK] Build failed ({report.summary.totalErrors} errors). Check Console.");
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.1.3`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.2.0`
 4. Click **Add**
 
-> Pinning the URL with `#v2.1.3` keeps the package hash stable across resolves. Bump the tag (e.g. `#v2.2.0`) to upgrade. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.2.0` keeps the package hash stable across resolves. Bump the tag (e.g. `#v2.2.0`) to upgrade. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 
@@ -114,6 +114,34 @@ Yes2SDK.StartGameAsync(onSuccess, onError);
 
 > **Important:** these three calls fire in three distinct stages — *don't chain them*. `InitializeAsync` is at app launch. `SetLoadingProgress` is updated as your assets load. `StartGameAsync` runs **only when the game is actually playable** (splash gone, scene loaded, accepting input). See [Quick Start](#quick-start) for the full pattern.
 
+#### `await`-friendly overloads
+
+Every `*Async` method has a `Task`-returning overload that takes a `CancellationToken`. Pass `CancellationToken.None` for no timeout, or a real token for cancellation/timeout support. Errors are thrown as `Yes2SDKException` (whose `ErrorCode` matches the `Error.ErrorCode` of the underlying failure):
+
+```csharp
+using System.Threading;
+using System.Threading.Tasks;
+using Yes2SDK;
+
+// Cancel init if it hangs for more than 10 seconds
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+try
+{
+    await Yes2SDK.InitializeAsync(cts.Token);
+    Debug.Log("SDK ready");
+}
+catch (Yes2SDKException ex) when (ex.ErrorCode == ErrorCode.NetworkError)
+{
+    // Platform unreachable — fall back or retry with backoff
+}
+catch (TaskCanceledException)
+{
+    // Init didn't complete inside the timeout
+}
+```
+
+The callback-based form is unchanged and still preferred for short-lived game-loop call sites where allocating Tasks is overkill.
+
 Handle pause / resume so your game reacts when the SDK pauses you (e.g. during an ad):
 
 ```csharp
@@ -163,6 +191,17 @@ adDismissed   → no reward (fires if the player skipped/closed early)
 ```
 
 > ⚠️ **Do NOT grant rewards in `afterAd`.** `afterAd` fires for both completion *and* dismissal — granting rewards there gives them away on skip. Always grant in `adViewed`.
+
+#### Concurrent ad guard
+
+`Ads.IsAdShowing()` returns `true` while a `ShowInterstitial` or `ShowRewarded` is in flight (between the call and `afterAd`/error). Calling `Show*` again while one is already showing is rejected immediately — `onError` fires with `ErrorCode.InvalidParams` and a message starting `"Another ad is already in flight (AdAlreadyShowing)…"`. Use `IsAdShowing()` to gate the UI that triggers ads:
+
+```csharp
+if (!Yes2SDK.Ads.IsAdShowing())
+{
+    rewardButton.interactable = true;
+}
+```
 
 ### Gameplay Tracking (required)
 
@@ -330,11 +369,9 @@ The QA Inspector in the Yes2Games Dashboard validates all of this automatically.
 ## Building
 
 1. Open **Yes2SDK > Build Window**
-2. Click **Apply Settings** — sets the WebGL template and build configuration
-3. Click **Build WebGL** or **Build and Run**
-4. Zip the build output folder
-5. Upload the zip to the **Yes2Games Dashboard**
-6. Run through the QA Inspector; when everything is green, **Request Review**
+2. Click **Build WebGL** (or **Build and Run** to launch in browser).
+
+The output folder is what you upload to the **Yes2Games Dashboard** — the dashboard handles SDK injection, platform bundling, and walks you through the QA Inspector and review request.
 
 ### Build Configuration
 
@@ -410,6 +447,18 @@ onError: err => {
 | `RateLimited` | Too many calls in a short window (e.g. ad spam protection). | Back off and try again later — don't retry immediately. |
 | `UserCancelled` | The player closed/dismissed a flow (e.g. login dialog, rewarded ad). | Not an error in the usual sense — silently respect the player's choice, no toast. |
 | `Unknown` | The error didn't match any of the above. | Log everything (`err.Code`, `err.Message`, `err.Context`) and treat as a hard failure. |
+
+---
+
+## Running alongside other SDKs
+
+Real games often ship with multiple platform SDKs in the same build (Yes2SDK + Poki + Yandex + Playgama, etc.). A few ground rules to keep them from stepping on each other:
+
+- **Init order.** Initialize Yes2SDK first. Yes2SDK figures out which actual platform is hosting the game and routes through it — initializing your own platform SDK directly first can race with Yes2SDK's detection.
+- **One owner for pause / resume.** Pick one SDK to drive `Time.timeScale` and `AudioListener.pause`. If both Yes2SDK and another SDK call resume/pause, you'll get oscillation. Recommended: subscribe to `Yes2SDK.OnPause` / `OnResume` and ignore the other SDK's equivalent.
+- **One owner for ads.** Don't call ads via two SDKs in the same session — the platform almost always rejects the second call. Pick the SDK that targets the platform you're actually hosted on.
+- **Namespace collisions.** If you have your own `Platform` type, qualify the Yes2SDK enum (`Yes2SDK.Platform`) at the call site or use a `using` alias (`using Y2 = Yes2SDK;`). C# resolves namespace-vs-type ambiguity by full qualification.
+- **Init timeout.** If you depend on Yes2SDK init completing before your other SDK's flow, wrap `InitializeAsync` in a `CancellationToken` with a timeout (see [`await`-friendly overloads](#await-friendly-overloads)) so your game doesn't hang on a wedged JS bridge.
 
 ---
 

--- a/Runtime/Ads/Yes2SDKAds.cs
+++ b/Runtime/Ads/Yes2SDKAds.cs
@@ -30,6 +30,11 @@ namespace Yes2SDK
         private static Action _bannerHiddenCallback;
         private static Action<Error> _bannerHideErrorCallback;
 
+        // True between any ShowInterstitial / ShowRewarded call and its
+        // afterAd / error completion. Used to reject concurrent ad calls and
+        // exposed via IsAdShowing().
+        private static bool _adInFlight;
+
         #endregion
 
         #region JavaScript Imports
@@ -77,6 +82,18 @@ namespace Yes2SDK
             Action afterAd = null,
             Action<Error> onError = null)
         {
+            if (_adInFlight)
+            {
+                onError?.Invoke(new Error
+                {
+                    Code = "InvalidParams",
+                    Message = "Another ad is already in flight (AdAlreadyShowing). Wait for afterAd before calling Show* again.",
+                    Context = "Yes2SDK.Ads.ShowInterstitial"
+                });
+                return;
+            }
+            _adInFlight = true;
+
             // Store callbacks
             _interstitialBeforeAdCallback = beforeAd;
             _interstitialAfterAdCallback = afterAd;
@@ -89,6 +106,7 @@ namespace Yes2SDK
             // Simulate ad flow in Editor
             _interstitialBeforeAdCallback?.Invoke();
             _interstitialAfterAdCallback?.Invoke();
+            _adInFlight = false;
 #endif
         }
 
@@ -125,6 +143,18 @@ namespace Yes2SDK
             Action adViewed = null,
             Action<Error> onError = null)
         {
+            if (_adInFlight)
+            {
+                onError?.Invoke(new Error
+                {
+                    Code = "InvalidParams",
+                    Message = "Another ad is already in flight (AdAlreadyShowing). Wait for afterAd before calling Show* again.",
+                    Context = "Yes2SDK.Ads.ShowRewarded"
+                });
+                return;
+            }
+            _adInFlight = true;
+
             // Store callbacks
             _rewardedBeforeAdCallback = beforeAd;
             _rewardedAfterAdCallback = afterAd;
@@ -149,6 +179,7 @@ namespace Yes2SDK
             {
                 _rewardedAdViewedCallback?.Invoke();
             }
+            _adInFlight = false;
 #endif
         }
 
@@ -230,6 +261,14 @@ namespace Yes2SDK
 #endif
         }
 
+        /// <summary>
+        /// Returns true while a `ShowInterstitial` or `ShowRewarded` call is in
+        /// progress (between the initial call and `afterAd`/error). Use this to
+        /// gate UI that triggers ads — hiding the "Watch for reward" button
+        /// while one is already showing prevents broken state.
+        /// </summary>
+        public bool IsAdShowing() => _adInFlight;
+
         #endregion
 
         #region Internal Callback Invocations (called by Bridge)
@@ -249,6 +288,7 @@ namespace Yes2SDK
         {
             _interstitialAfterAdCallback?.Invoke();
             ClearInterstitialCallbacks();
+            _adInFlight = false;
         }
 
         /// <summary>
@@ -258,6 +298,7 @@ namespace Yes2SDK
         {
             _interstitialErrorCallback?.Invoke(error);
             ClearInterstitialCallbacks();
+            _adInFlight = false;
         }
 
         /// <summary>
@@ -283,6 +324,7 @@ namespace Yes2SDK
         {
             _rewardedAdDismissedCallback?.Invoke();
             ClearRewardedCallbacks();
+            _adInFlight = false;
         }
 
         /// <summary>
@@ -292,6 +334,7 @@ namespace Yes2SDK
         {
             _rewardedAdViewedCallback?.Invoke();
             ClearRewardedCallbacks();
+            _adInFlight = false;
         }
 
         /// <summary>
@@ -301,6 +344,7 @@ namespace Yes2SDK
         {
             _rewardedErrorCallback?.Invoke(error);
             ClearRewardedCallbacks();
+            _adInFlight = false;
         }
 
         /// <summary>

--- a/Runtime/Auth/Yes2SDKAuth.cs
+++ b/Runtime/Auth/Yes2SDKAuth.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -123,6 +125,28 @@ namespace Yes2SDK
             InvokeAccountLinkError(FeatureNotSupportedError("Yes2SDK.Auth.ShowAccountLinkPromptAsync"));
 #endif
         }
+
+        // Task-returning overloads.
+
+        public Task<AuthUser> GetCurrentUserAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<AuthUser>(
+                (success, error) => GetCurrentUserAsync(success, error),
+                cancellationToken);
+
+        public Task<AuthUser> SignInAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<AuthUser>(
+                (success, error) => SignInAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetTokenAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetTokenAsync(success, error),
+                cancellationToken);
+
+        public Task<bool> ShowAccountLinkPromptAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<bool>(
+                (success, error) => ShowAccountLinkPromptAsync(success, error),
+                cancellationToken);
 
         #endregion
 

--- a/Runtime/Friends/Yes2SDKFriends.cs
+++ b/Runtime/Friends/Yes2SDKFriends.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -48,6 +50,11 @@ namespace Yes2SDK
             InvokeListFriendsError(FeatureNotSupportedError("Yes2SDK.Friends.ListFriendsAsync"));
 #endif
         }
+
+        public Task<FriendsPage> ListFriendsAsync(int page, int size, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<FriendsPage>(
+                (success, error) => ListFriendsAsync(page, size, success, error),
+                cancellationToken);
 
         #endregion
 

--- a/Runtime/Game/Yes2SDKGame.cs
+++ b/Runtime/Game/Yes2SDKGame.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -116,6 +118,11 @@ namespace Yes2SDK
             InvokeInviteLinkError(FeatureNotSupportedError("Yes2SDK.Game.InviteLinkAsync"));
 #endif
         }
+
+        public Task<string> InviteLinkAsync(Dictionary<string, string> parameters, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => InviteLinkAsync(parameters, success, error),
+                cancellationToken);
 
         /// <summary>
         /// Get the value of an invite parameter from the URL.

--- a/Runtime/Player/Yes2SDKPlayer.cs
+++ b/Runtime/Player/Yes2SDKPlayer.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using UnityEngine;
 
@@ -160,6 +162,38 @@ namespace Yes2SDK
             InvokeGetSignedPlayerInfoError(FeatureNotSupportedError("Yes2SDK.Player.GetSignedPlayerInfoAsync"));
 #endif
         }
+
+        // Task-returning overloads.
+
+        public Task<PlayerInfo> GetPlayerAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<PlayerInfo>(
+                (success, error) => GetPlayerAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetDataAsync(string[] keys, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetDataAsync(keys, success, error),
+                cancellationToken);
+
+        public Task SetDataAsync(string dataJson, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask(
+                (success, error) => SetDataAsync(dataJson, success, error),
+                cancellationToken);
+
+        public Task FlushDataAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask(
+                (success, error) => FlushDataAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetConnectedPlayersAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetConnectedPlayersAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetSignedPlayerInfoAsync(string payload, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetSignedPlayerInfoAsync(payload, success, error),
+                cancellationToken);
 
         /// <summary>
         /// Whether player data persistence is supported on the current platform.

--- a/Runtime/TaskCallbackHelper.cs
+++ b/Runtime/TaskCallbackHelper.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yes2SDK
+{
+    /// <summary>
+    /// Internal helper that converts callback-based SDK methods (the original
+    /// signature shape) into Task-returning overloads. Cancellation marks the
+    /// returned Task as cancelled — the underlying platform call may still
+    /// run, but its result is dropped.
+    /// </summary>
+    internal static class TaskCallbackHelper
+    {
+        public static Task<T> ToTask<T>(
+            Action<Action<T>, Action<Error>> invoke,
+            CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<T>();
+            CancellationTokenRegistration registration = default;
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.Register(
+                    () => tcs.TrySetCanceled(cancellationToken));
+            }
+
+            invoke(
+                result =>
+                {
+                    registration.Dispose();
+                    tcs.TrySetResult(result);
+                },
+                error =>
+                {
+                    registration.Dispose();
+                    tcs.TrySetException(new Yes2SDKException(error));
+                });
+
+            return tcs.Task;
+        }
+
+        public static Task ToTask(
+            Action<Action, Action<Error>> invoke,
+            CancellationToken cancellationToken)
+        {
+            var tcs = new TaskCompletionSource<object>();
+            CancellationTokenRegistration registration = default;
+            if (cancellationToken.CanBeCanceled)
+            {
+                registration = cancellationToken.Register(
+                    () => tcs.TrySetCanceled(cancellationToken));
+            }
+
+            invoke(
+                () =>
+                {
+                    registration.Dispose();
+                    tcs.TrySetResult(null);
+                },
+                error =>
+                {
+                    registration.Dispose();
+                    tcs.TrySetException(new Yes2SDKException(error));
+                });
+
+            return tcs.Task;
+        }
+    }
+}

--- a/Runtime/TaskCallbackHelper.cs.meta
+++ b/Runtime/TaskCallbackHelper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce16599ce13b402da310b6bdae2abb43

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Yes2SDK
@@ -66,7 +68,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.1.3";
+        public static string Version => "2.2.0";
 
         private static Yes2SDKAds _ads;
 
@@ -371,6 +373,18 @@ namespace Yes2SDK
         }
 
         /// <summary>
+        /// Initialize the Yes2SDK and await completion. The token cancels the
+        /// awaiting Task — the underlying platform init may still complete in
+        /// the background, but its result is dropped.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token (use <see cref="CancellationToken.None"/> for no timeout).</param>
+        /// <returns>Task that completes when initialization succeeds or throws <see cref="Yes2SDKException"/>.</returns>
+        public static Task InitializeAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask(
+                (onSuccess, onError) => InitializeAsync(onSuccess, onError),
+                cancellationToken);
+
+        /// <summary>
         /// Notify the platform that the game has finished loading and is ready to play.
         /// Call this after your game assets are loaded.
         /// </summary>
@@ -399,6 +413,16 @@ namespace Yes2SDK
             Callbacks.InvokeStartGameSuccess();
 #endif
         }
+
+        /// <summary>
+        /// Notify the platform that the game has finished loading and await acknowledgement.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token.</param>
+        /// <returns>Task that completes when start is acknowledged or throws <see cref="Yes2SDKException"/>.</returns>
+        public static Task StartGameAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask(
+                (onSuccess, onError) => StartGameAsync(onSuccess, onError),
+                cancellationToken);
 
         /// <summary>
         /// Update the loading progress shown to the player.

--- a/Runtime/Yes2SDKException.cs
+++ b/Runtime/Yes2SDKException.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace Yes2SDK
+{
+    /// <summary>
+    /// Exception wrapping a Yes2SDK <see cref="Error"/> for use with the
+    /// Task-returning overloads of the SDK's async APIs. The original
+    /// <see cref="Error"/> struct is available via <see cref="SdkError"/>
+    /// so callers can branch on <see cref="ErrorCode"/> in a catch block.
+    /// </summary>
+    public class Yes2SDKException : Exception
+    {
+        public Error SdkError { get; }
+        public ErrorCode ErrorCode => SdkError.ErrorCode;
+
+        public Yes2SDKException(Error sdkError)
+            : base(string.IsNullOrEmpty(sdkError.Message)
+                ? $"Yes2SDK error ({sdkError.ErrorCode}): {sdkError.Code}"
+                : sdkError.Message)
+        {
+            SdkError = sdkError;
+        }
+    }
+}

--- a/Runtime/Yes2SDKException.cs.meta
+++ b/Runtime/Yes2SDKException.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4e23507c33224579975508de3e7ff7c2

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.1.3",
+    "version": "2.2.0",
     "displayName": "Yes2SDK",
-    "description": "Yes2SDK Unity package for the SuperSDK pipeline — build once, publish to 5 platforms",
+    "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",
     "unityRelease": "0f1",
     "documentationUrl": "https://github.com/yes2games/yes2sdk-unity",


### PR DESCRIPTION
## Summary
Round-3 of post-launch integrator feedback. Pure Unity-side changes — no Core SDK dependency. Bumps to **2.2.0**.

## Closes / partially closes

| Issue | Status |
|---|---|
| #26 — async/await Task overloads | **Closes.** Every `*Async` API gets a `Task`-returning overload taking a `CancellationToken`. Errors throw `Yes2SDKException` (ErrorCode mirrors `Error.ErrorCode`). |
| #27 — Ad readiness / `IsAdShowing` | **Closes the in-flight-guard part.** `Ads.IsAdShowing()` exposes the in-flight state; concurrent `Show*` calls now reject immediately. The full `IsRewardedAdAvailable()` check needs Core SDK work — tracked as remaining scope on #27. |
| #33 — Init timeout + multi-SDK doc | **Closes the init-timeout part** (via the new `CancellationToken` overloads). Adds a "Running alongside other SDKs" README section covering init order, single-owner pause/resume + ads, and namespace collisions. |

## Editor window refresh
Same minimum content as before — but now with structure: Status panel (template ✓ / WebGL target ✓ / scene count ✓ at a glance), Build card (path + Build WebGL + Build and Run + inline Apply Settings / Reinstall Template), Quick links row (Dashboard / Docs / Feedback). Footer reads version from `Yes2SDK.Version` instead of a hardcoded string. Removed the dead Show Debug Logs toggle (logger never read it) and the workflow hint block.

## Still open from feedback round (need Core SDK changes — round 4)
- #22 — `IsSupported()` audit on Friends/Banners/Score
- #27 (full) — `IsRewardedAdAvailable()` per-platform readiness check
- #28 — `LogLevelEnd` `durationSeconds` parameter
- #30 — Async data setters returning success boolean

## Test plan
- [x] `Yes2SDK > Build Window` — Status panel shows correct ticks/warnings (toggle WebGL target off/on, remove all scenes).
- [x] Install Template → Status flips to ready, Build card appears.
- [x] Build WebGL with template missing → loud build failure (BuildGuard from 2.1.x still works).
- [x] `await Yes2SDK.InitializeAsync(CancellationToken.None)` succeeds.
- [x] `await Yes2SDK.InitializeAsync(new CancellationTokenSource(TimeSpan.FromMilliseconds(1)).Token)` throws `TaskCanceledException`.
- [x] Calling `Ads.ShowInterstitial` twice without waiting → second call's `onError` fires with `ErrorCode.InvalidParams`.
- [x] Render the README — Building section is short, multi-SDK section reads cleanly, await section compiles.