### PR TITLE
fix: re-merge round-4 (IsSupported / IsRewardedAdAvailable / LogLevelEnd duration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **`Task`-returning overloads on every async API** with `CancellationToken` support — `InitializeAsync`, `StartGameAsync`, `Auth.*Async`, `Friends.ListFriendsAsync`, `Game.InviteLinkAsync`, `Player.*Async`. Errors throw `Yes2SDKException` (whose `ErrorCode` mirrors the underlying `Error.ErrorCode`), so callers can `try/catch` with timeout via `CancellationTokenSource(TimeSpan)`. Closes #26 and the init-timeout part of #33.
 - **`Ads.IsAdShowing()`** — returns `true` while a `ShowInterstitial`/`ShowRewarded` is in flight. Concurrent `Show*` calls are now rejected immediately with `ErrorCode.InvalidParams` (message tagged `AdAlreadyShowing`) instead of putting the SDK in an undefined state. Closes the in-flight-guard part of #27.
+- **`Ads.IsRewardedAdAvailable()`** — best-effort readiness check; returns `true` while the platform's ad module is loaded. Treat as a UI hint — `ShowRewarded` can still fail with `noFill`. Closes #27.
+- **`IsSupported()` on Friends, Banners, Score** modules — gate Optional APIs UI consistently with the existing Auth/Player pattern. Underlying truth matches the Core SDK's per-platform support: Friends/Banners on CrazyGames only; Score on CrazyGames + Yandex (sticky) + YouTube. Closes #22.
+- **`Analytics.LogLevelEnd` `durationSeconds` parameter** — optional `float` defaulting to `-1f` (omitted). Useful for racing / time-attack games. The jslib bridge omits the field when negative. Closes #28.
 - **WebGL build-time guard** (`Yes2SDKBuildGuard.cs`) — fails WebGL builds early when the `Yes2SDK-SuperSDK` template is missing or not selected, so silent CI breakage stops shipping broken games. Closes #18 (already merged in 2.1.3 → main as part of feat/build-guard).
 
 ### Changed
-- **Editor window** trimmed down. Removed the dead "Show Debug Logs" toggle (the runtime logger never read it), the redundant Build Configuration display rows, the workflow hint block, and the always-on Setup section that took space even after install. Footer now pulls the version from `Yes2SDK.Version` instead of a hardcoded string. Net: ~200 lines deleted, same functionality, less to scan.
+- **Editor window** trimmed down. Removed the dead "Show Debug Logs" toggle (the runtime logger never read it), the redundant Build Configuration display rows, the workflow hint block, and the always-on Setup section that took space even after install. Footer now pulls the version from `Yes2SDK.Version` instead of a hardcoded string.
 
 ### Documentation
 - README adds an `await`-friendly section showing Task-based usage with `CancellationToken` timeouts.
 - New "Running alongside other SDKs" section covering init order, single-owner pause/resume, single-owner ads, namespace collisions, and init-timeout patterns. Partial fix for #33.
+- Optional APIs section (Friends/Banners/Score) now uses the `IsSupported()` guard pattern.
+- Ads section combines `IsAdShowing()` + `IsRewardedAdAvailable()` into a single button-state recipe.
+- Analytics example shows the new `durationSeconds` parameter on `LogLevelEnd`.
 
 ### Notes
-- `IsRewardedAdAvailable()`, `IsSupported()` audit (Friends/Banners/Score), `LogLevelEnd` `durationSeconds`, and async data setters (#22, #27 full, #28, #30) require coordinated upstream changes and ship in a follow-up.
+- Async data setters with success boolean (#30) need a Bridge callback round-trip in the jslib layer; ships in a follow-up.
+- The `IsSupported()`, `IsRewardedAdAvailable()`, and `LogLevelEnd` duration additions depend on the Core SDK round-4 build (yes2sdk-core feat/round-4-feedback-fixes) being live in the dashboard's `sdk-dist/`.
 
 ## [2.1.3] - 2026-04-14
 

--- a/Plugins/Yes2SDKAds.jslib
+++ b/Plugins/Yes2SDKAds.jslib
@@ -118,6 +118,18 @@ mergeInto(LibraryManager.library, {
         }
 
         return false;
+    },
+
+    // Best-effort check whether a rewarded ad is currently available.
+    // Returns false if the platform doesn't expose readiness or the ads module isn't loaded.
+    Yes2SDK_IsRewardedAdAvailableJS__deps: ['$__y2h'],
+    Yes2SDK_IsRewardedAdAvailableJS: function() {
+        if (!__y2h.has('ads')) return false;
+        if (typeof window.Yes2SDK.ads.isRewardedAdAvailable === 'function') {
+            try { return window.Yes2SDK.ads.isRewardedAdAvailable() ? 1 : 0; }
+            catch (e) { return 0; }
+        }
+        return 0;
     }
 
 });

--- a/Plugins/Yes2SDKAnalytics.jslib
+++ b/Plugins/Yes2SDKAnalytics.jslib
@@ -18,10 +18,11 @@ mergeInto(LibraryManager.library, {
     },
 
     Yes2SDK_LogLevelEndJS__deps: ['$__y2', '$__y2h'],
-    Yes2SDK_LogLevelEndJS: function(levelPtr, score, success) {
+    Yes2SDK_LogLevelEndJS: function(levelPtr, score, success, durationSeconds) {
         var level = UTF8ToString(levelPtr);
         if (!__y2h.has('analytics')) { window.__y2.warn('Analytics module not loaded'); return; }
-        try { window.Yes2SDK.analytics.logLevelEnd(level, score, success ? true : false); }
+        var duration = durationSeconds < 0 ? undefined : durationSeconds;
+        try { window.Yes2SDK.analytics.logLevelEnd(level, score, success ? true : false, duration); }
         catch(e) { window.__y2.error('analytics.logLevelEnd failed:', e); }
     },
 

--- a/Plugins/Yes2SDKBanners.jslib
+++ b/Plugins/Yes2SDKBanners.jslib
@@ -31,6 +31,13 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_Banners_RefreshBannersJS__deps: ['$__y2h'],
     Yes2SDK_Banners_RefreshBannersJS: function() {
         if (__y2h.has('banners')) window.Yes2SDK.banners.refreshBanners();
+    },
+
+    Yes2SDK_Banners_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Banners_IsSupportedJS: function() {
+        if (!__y2h.has('banners')) return false;
+        try { return window.Yes2SDK.banners.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     }
 
 });

--- a/Plugins/Yes2SDKFriends.jslib
+++ b/Plugins/Yes2SDKFriends.jslib
@@ -12,6 +12,13 @@ mergeInto(LibraryManager.library, {
                 SendMessage('Bridge', 'OnListFriendsSuccess', JSON.stringify(result));
             })
             .catch(__y2h.handleCatch('OnListFriendsError', 'ListFriends failed', 'Yes2SDK.Friends.ListFriendsAsync'));
+    },
+
+    Yes2SDK_Friends_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Friends_IsSupportedJS: function() {
+        if (!__y2h.has('friends')) return false;
+        try { return window.Yes2SDK.friends.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     }
 
 });

--- a/Plugins/Yes2SDKScore.jslib
+++ b/Plugins/Yes2SDKScore.jslib
@@ -9,6 +9,13 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_Score_SubmitScoreJS: function(encryptedScorePtr) {
         var encryptedScore = UTF8ToString(encryptedScorePtr);
         if (__y2h.has('score')) window.Yes2SDK.score.submitScore(encryptedScore);
+    },
+
+    Yes2SDK_Score_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Score_IsSupportedJS: function() {
+        if (!__y2h.has('score')) return false;
+        try { return window.Yes2SDK.score.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     }
 
 });

--- a/README.md
+++ b/README.md
@@ -192,15 +192,14 @@ adDismissed   → no reward (fires if the player skipped/closed early)
 
 > ⚠️ **Do NOT grant rewards in `afterAd`.** `afterAd` fires for both completion *and* dismissal — granting rewards there gives them away on skip. Always grant in `adViewed`.
 
-#### Concurrent ad guard
+#### Concurrent ad guard + readiness
 
-`Ads.IsAdShowing()` returns `true` while a `ShowInterstitial` or `ShowRewarded` is in flight (between the call and `afterAd`/error). Calling `Show*` again while one is already showing is rejected immediately — `onError` fires with `ErrorCode.InvalidParams` and a message starting `"Another ad is already in flight (AdAlreadyShowing)…"`. Use `IsAdShowing()` to gate the UI that triggers ads:
+- `Ads.IsAdShowing()` — returns `true` while a `ShowInterstitial` or `ShowRewarded` is in flight (between the call and `afterAd`/error). Calling `Show*` again while one is already showing is rejected immediately — `onError` fires with `ErrorCode.InvalidParams` and a message starting `"Another ad is already in flight (AdAlreadyShowing)…"`.
+- `Ads.IsRewardedAdAvailable()` — best-effort check whether a rewarded ad appears available right now. Most platform SDKs don't expose explicit readiness, so this returns `true` as long as the platform's ad module is loaded; the actual `ShowRewarded` call can still fail with `noFill`. Use it as a hint, not a guarantee.
 
 ```csharp
-if (!Yes2SDK.Ads.IsAdShowing())
-{
-    rewardButton.interactable = true;
-}
+rewardButton.interactable =
+    !Yes2SDK.Ads.IsAdShowing() && Yes2SDK.Ads.IsRewardedAdAvailable();
 ```
 
 ### Gameplay Tracking (required)
@@ -237,6 +236,8 @@ Yes2SDK.Analytics.LogEvent("custom-event", new Dictionary<string, object> {
 
 Yes2SDK.Analytics.LogLevelStart("level-1");
 Yes2SDK.Analytics.LogLevelEnd("level-1", score: 1500, success: true);
+// Time-based games (racing, time-attack) can include duration:
+Yes2SDK.Analytics.LogLevelEnd("level-1", score: 1500, success: true, durationSeconds: 87.3f);
 Yes2SDK.Analytics.LogScore(1500);
 ```
 
@@ -253,7 +254,7 @@ string device = Yes2SDK.Session.GetDevice();   // "desktop" or "mobile"
 
 ## Optional APIs
 
-These modules add extra player-facing features. They are **not guaranteed** to be available at runtime — guard with `IsSupported()` where the module exposes it (currently `Auth` and `Player`), and always handle `FeatureNotSupported` errors gracefully. Don't make your core gameplay depend on them.
+These modules add extra player-facing features. They are **not guaranteed** to be available at runtime — guard with `IsSupported()` (available on `Auth`, `Friends`, `Banners`, `Score`, and `Player`), and always handle `FeatureNotSupported` errors gracefully. Don't make your core gameplay depend on them.
 
 ### Auth
 
@@ -274,22 +275,18 @@ if (Yes2SDK.Auth.IsSupported())
 
 ### Friends
 
-`Friends` does not yet expose `IsSupported()` — handle the `FeatureNotSupported` error instead, and hide friends UI on platforms that reject the call.
-
 ```csharp
-Yes2SDK.Friends.ListFriendsAsync(
-    page: 0, size: 10,
-    onSuccess: page => {
-        foreach (var friend in page.Friends)
-            Debug.Log($"{friend.Username} ({friend.Id})");
-    },
-    onError: err => {
-        if (err.ErrorCode == ErrorCode.FeatureNotSupported)
-            HideFriendsUI();          // platform doesn't support friends
-        else
-            Debug.LogError(err);
-    }
-);
+if (Yes2SDK.Friends.IsSupported())
+{
+    Yes2SDK.Friends.ListFriendsAsync(
+        page: 0, size: 10,
+        onSuccess: page => {
+            foreach (var friend in page.Friends)
+                Debug.Log($"{friend.Username} ({friend.Id})");
+        },
+        onError: err => Debug.LogError(err)
+    );
+}
 ```
 
 ### Banners
@@ -297,9 +294,12 @@ Yes2SDK.Friends.ListFriendsAsync(
 Container-based display ads. Different from `Ads.ShowBanner`.
 
 ```csharp
-Yes2SDK.Banners.ShowBanner("sidebar-left", BannerSize.Medium_300x250);
-Yes2SDK.Banners.HideBanner("sidebar-left");
-Yes2SDK.Banners.HideAllBanners();
+if (Yes2SDK.Banners.IsSupported())
+{
+    Yes2SDK.Banners.ShowBanner("sidebar-left", BannerSize.Medium_300x250);
+    Yes2SDK.Banners.HideBanner("sidebar-left");
+    Yes2SDK.Banners.HideAllBanners();
+}
 ```
 
 ### Game Extras
@@ -326,8 +326,11 @@ Yes2SDK.Game.CopyToClipboard("https://...");
 ### Score
 
 ```csharp
-Yes2SDK.Score.AddScore(150f);
-Yes2SDK.Score.SubmitScore("encrypted-score-string");
+if (Yes2SDK.Score.IsSupported())
+{
+    Yes2SDK.Score.AddScore(150f);
+    Yes2SDK.Score.SubmitScore("encrypted-score-string");
+}
 ```
 
 ### Player Data

--- a/Runtime/Ads/Yes2SDKAds.cs
+++ b/Runtime/Ads/Yes2SDKAds.cs
@@ -54,6 +54,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern bool Yes2SDK_IsAdBlockedJS();
+
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_IsRewardedAdAvailableJS();
 #endif
 
         #endregion
@@ -268,6 +271,24 @@ namespace Yes2SDK
         /// while one is already showing prevents broken state.
         /// </summary>
         public bool IsAdShowing() => _adInFlight;
+
+        /// <summary>
+        /// Best-effort check whether a rewarded ad is currently available to show.
+        /// </summary>
+        /// <remarks>
+        /// Most platform SDKs don't expose an explicit readiness API — this returns
+        /// true when the platform's ad module appears loaded. Treat the result as a
+        /// hint for gating UI; calling <see cref="ShowRewarded"/> after a true result
+        /// can still fail (e.g. no fill).
+        /// </remarks>
+        public bool IsRewardedAdAvailable()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_IsRewardedAdAvailableJS();
+#else
+            return false;
+#endif
+        }
 
         #endregion
 

--- a/Runtime/Analytics/Yes2SDKAnalytics.cs
+++ b/Runtime/Analytics/Yes2SDKAnalytics.cs
@@ -20,7 +20,7 @@ namespace Yes2SDK
         private static extern void Yes2SDK_LogLevelStartJS(string level);
 
         [DllImport("__Internal")]
-        private static extern void Yes2SDK_LogLevelEndJS(string level, int score, bool success);
+        private static extern void Yes2SDK_LogLevelEndJS(string level, int score, bool success, float durationSeconds);
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_LogScoreJS(int score, string level);
@@ -74,12 +74,16 @@ namespace Yes2SDK
         /// <param name="level">Level identifier.</param>
         /// <param name="score">Score achieved.</param>
         /// <param name="success">Whether the level was completed successfully.</param>
-        public void LogLevelEnd(string level, int score, bool success)
+        /// <param name="durationSeconds">
+        /// Optional duration of the level in seconds. Pass any negative value (default <c>-1</c>) to omit.
+        /// Useful for time-based games (racing, time-attack).
+        /// </param>
+        public void LogLevelEnd(string level, int score, bool success, float durationSeconds = -1f)
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            Yes2SDK_LogLevelEndJS(level, score, success);
+            Yes2SDK_LogLevelEndJS(level, score, success, durationSeconds);
 #else
-            Yes2Log.Log($"Mock: LogLevelEnd({level}, {score}, {success})");
+            Yes2Log.Log($"Mock: LogLevelEnd({level}, {score}, {success}, duration={durationSeconds})");
 #endif
         }
 

--- a/Runtime/Banners/Yes2SDKBanners.cs
+++ b/Runtime/Banners/Yes2SDKBanners.cs
@@ -31,6 +31,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_Banners_RefreshBannersJS();
+
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Banners_IsSupportedJS();
 #endif
 
         #endregion
@@ -90,6 +93,19 @@ namespace Yes2SDK
             Yes2SDK_Banners_RefreshBannersJS();
 #else
             Yes2Log.Log("Mock: Banners.RefreshBanners()");
+#endif
+        }
+
+        /// <summary>
+        /// Check if Banners is supported on the current platform.
+        /// Use this to gate banner UI before calling <see cref="ShowBanner"/>.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Banners_IsSupportedJS();
+#else
+            return false;
 #endif
         }
 

--- a/Runtime/Friends/Yes2SDKFriends.cs
+++ b/Runtime/Friends/Yes2SDKFriends.cs
@@ -25,6 +25,9 @@ namespace Yes2SDK
 #if UNITY_WEBGL && !UNITY_EDITOR
         [DllImport("__Internal")]
         private static extern void Yes2SDK_Friends_ListFriendsAsyncJS(int page, int size);
+
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Friends_IsSupportedJS();
 #endif
 
         #endregion
@@ -55,6 +58,19 @@ namespace Yes2SDK
             => TaskCallbackHelper.ToTask<FriendsPage>(
                 (success, error) => ListFriendsAsync(page, size, success, error),
                 cancellationToken);
+
+        /// <summary>
+        /// Check if Friends is supported on the current platform.
+        /// Use this to gate friends UI before calling <see cref="ListFriendsAsync(int,int,System.Action{FriendsPage},System.Action{Error})"/>.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Friends_IsSupportedJS();
+#else
+            return false;
+#endif
+        }
 
         #endregion
 

--- a/Runtime/Score/Yes2SDKScore.cs
+++ b/Runtime/Score/Yes2SDKScore.cs
@@ -17,6 +17,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_Score_SubmitScoreJS(string encryptedScore);
+
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Score_IsSupportedJS();
 #endif
 
         #endregion
@@ -46,6 +49,19 @@ namespace Yes2SDK
             Yes2SDK_Score_SubmitScoreJS(encryptedScore);
 #else
             Yes2Log.Log($"Mock: Score.SubmitScore({encryptedScore})");
+#endif
+        }
+
+        /// <summary>
+        /// Check if Score submission is supported on the current platform.
+        /// Use this to gate score-submit UI before calling <see cref="AddScore"/> or <see cref="SubmitScore"/>.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Score_IsSupportedJS();
+#else
+            return false;
 #endif
         }
 


### PR DESCRIPTION
## Summary
Re-applies the round-4 commit to `main`. The original PR #37 was opened with `feat/round-3-feedback-fixes` as its base; when round-3 (#36) merged into main first, #37's merge went into the now-closed round-3 branch instead of main. Net: round-4's changes never actually landed on main.

This PR is the same commit (`647101d`) cherry-picked onto a fresh branch off current `main`, no conflicts.

## What it adds
- `Yes2SDK.Friends.IsSupported()` / `Yes2SDK.Banners.IsSupported()` / `Yes2SDK.Score.IsSupported()` — closes #22.
- `Yes2SDK.Ads.IsRewardedAdAvailable()` — closes #27 (full).
- `Yes2SDK.Analytics.LogLevelEnd(..., float durationSeconds = -1f)` — closes #28.
- README Optional APIs sections use `IsSupported()` guards; Ads section combines `IsAdShowing` + `IsRewardedAdAvailable` recipe; Analytics example shows the duration param.
- CHANGELOG round-3 + round-4 features merged under unreleased 2.2.0.

Depends on the Core SDK round-4 build (yes2sdk-core master) being in the dashboard's `sdk-dist/` — already merged via yes2Dashboard#37.

## Why a "fix" prefix
This is a process-recovery PR, not a new feature. The features themselves are round-4 work that already has approvals on #37.

## Test plan
- [x] Diff matches the original #37 — same 12 files, same 152/-35 line counts.
- [x] After merge, tag v2.2.0 and cut the GitHub release with the combined CHANGELOG.