### PR TITLE
v2.3.0 — fix Yes2Log GUID collision, redesign Build Window, throttle progress logging

### DIFF
--- a/Assets/WebGLTemplates/Yes2SDK-SuperSDK/index.html
+++ b/Assets/WebGLTemplates/Yes2SDK-SuperSDK/index.html
@@ -215,11 +215,18 @@
     var script = document.createElement("script");
     script.src = loaderUrl;
     script.onload = function() {
+      var lastSdkProgressPct = -1;
       createUnityInstance(canvas, config, function(progress) {
         Y2GLoader.setProgress(progress * 100);
-        // Report progress to Yes2SDK if available
-        if (window.Yes2SDK && window.Yes2SDK.setLoadingProgress) {
-          window.Yes2SDK.setLoadingProgress(Math.round(progress * 100));
+        // Report integer-percentage progress to Yes2SDK only when it
+        // changes — the dashboard inspector logs every call, so an
+        // unthrottled forward fills the boot console with hundreds of
+        // duplicate "Loading progress" entries.
+        var pct = Math.round(progress * 100);
+        if (pct !== lastSdkProgressPct &&
+            window.Yes2SDK && window.Yes2SDK.setLoadingProgress) {
+          window.Yes2SDK.setLoadingProgress(pct);
+          lastSdkProgressPct = pct;
         }
       }).then(function(unityInstance) {
         Y2GLoader.complete();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-04-30
+
+### Fixed
+- **`Yes2Log.cs.meta` GUID collision with `com.unity.ai.assistant`** (#39) — meta file shipped with a hand-typed placeholder GUID that collided with the AI Assistant package. Unity silently ignored one of the two, so projects using both packages failed to compile with `CS0103: Yes2Log does not exist`. Regenerated to a proper random GUID.
+- **WebGL template `setLoadingProgress` log spam** (#42) — `index.html` forwarded every Unity progress tick to the SDK, which the dashboard inspector logged as "Loading progress" hundreds of times per build. Throttled to forward only when the integer percentage changes — at most 101 calls per build.
+
+### Changed
+- **Build Window no longer auto-overrides Player Settings on every build** (#40). The previous version called `BuildConfig.Default.ApplySettings()` inside `BuildGame()`, silently resetting Exception Support / Compression / Stripping / Template each time the user clicked Build. The new Build Window has a collapsible **WebGL Settings** panel that inline-edits Player Settings (no Apply step) and a **Reset to recommended** button for opt-in re-apply. `Yes2SDKBuildGuard` still enforces the `Yes2SDK-SuperSDK` template — the only truly mandatory setting.
+- **New `Build Mode` dropdown** with Production / Production Safe / Diagnostic options. Production Safe forces Exception Support to `Explicitly Thrown` for one build (useful when Player Settings is `None`). Diagnostic forces `Full With Stacktrace`. Both restore Player Settings after the build via `IPostprocessBuildWithReport`.
+- **`BuildConfig.Default.exceptionSupport`** flipped from `None` → `ExplicitlyThrownExceptionsOnly` (#41). `None` is smaller but breaks projects where a dependency uses `try/catch` (Newtonsoft.Json, etc.). The new default is ~10% larger but compatible with the .NET ecosystem.
+
+### Documentation
+- README Build Configuration table reworked: added Memory Size row, expanded Notes column, prominent warning explaining `None` vs `Explicitly Thrown`.
+- New "Build Mode for diagnostics" subsection.
+- "Where to set these" updated to lead with the Build Window's Settings panel.
+
+### Behaviour notes for users on upgrade
+
+- Existing builds will get `ExplicitlyThrownExceptionsOnly` for Exception Support unless overridden — ~10% larger but more robust.
+- The Build Window now respects custom Player Settings rather than silently overwriting them. Verify your active settings via *Yes2SDK > Build Window > WebGL Settings*.
+- The `Apply Settings` link has been renamed **Reset to recommended** and moved into the WebGL Settings foldout.
+
 ## [2.2.0] - 2026-04-29
 
 ### Added

--- a/Editor/BuildConfig.cs
+++ b/Editor/BuildConfig.cs
@@ -31,16 +31,23 @@ namespace Yes2SDK.Editor
         }
 
         /// <summary>
-        /// Default build config for the SuperSDK pipeline.
+        /// Recommended build config for the SuperSDK pipeline. Surfaced in
+        /// the Build Window's "Reset to recommended" button — NOT auto-applied
+        /// during builds (which was the source of issue #40 — the override
+        /// blocked diagnostic builds).
         /// - No compression (dashboard/platform handles CDN compression)
         /// - Medium code stripping for size
-        /// - No exceptions for production
+        /// - Explicitly Thrown exceptions: catches throws from Newtonsoft.Json
+        ///   and other third-party libs that use try/catch as control flow.
+        ///   Only ~10% larger than None and far more compatible with the
+        ///   .NET ecosystem. Use None only if you've audited your full
+        ///   dependency graph for throws.
         /// </summary>
         public static BuildConfig Default => new BuildConfig(
             compression: WebGLCompressionFormat.Disabled,
             decompressionFallback: false,
             codeStripping: ManagedStrippingLevel.Medium,
-            exceptionSupport: WebGLExceptionSupport.None,
+            exceptionSupport: WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly,
             description: "Build for Yes2SDK Dashboard.\n" +
                          "Upload the build zip to the dashboard to inject SDK and bundle for specific platforms.\n" +
                          "No compression — platforms handle CDN delivery."

--- a/Editor/Yes2SDKBuildModeOverride.cs
+++ b/Editor/Yes2SDKBuildModeOverride.cs
@@ -1,0 +1,93 @@
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// Persistent state for the Build Window's "Build Mode" radio. The user
+    /// picks Production / Production Safe / Diagnostic; the choice persists
+    /// across Editor sessions via EditorPrefs.
+    /// </summary>
+    public static class Yes2SDKBuildMode
+    {
+        public enum Mode
+        {
+            Production,
+            ProductionSafe,
+            Diagnostic,
+        }
+
+        private const string EditorPrefsKey = "Yes2SDK.BuildMode";
+
+        public static Mode Current
+        {
+            get => (Mode)EditorPrefs.GetInt(EditorPrefsKey, (int)Mode.Production);
+            set => EditorPrefs.SetInt(EditorPrefsKey, (int)value);
+        }
+
+        public static string DisplayName(Mode mode) => mode switch
+        {
+            Mode.Production => "Production",
+            Mode.ProductionSafe => "Production Safe (Explicitly Thrown)",
+            Mode.Diagnostic => "Diagnostic (Full With Stacktrace)",
+            _ => mode.ToString(),
+        };
+    }
+
+    /// <summary>
+    /// Build-time override that lets the user temporarily swap WebGL Exception
+    /// Support for a single build via the Build Window's Build Mode radio.
+    /// Player Settings is restored after the build, so the user's persistent
+    /// configuration isn't silently mutated.
+    ///
+    /// callbackOrder=100 places this AFTER Yes2SDKBuildGuard (order 0) so the
+    /// guard's template check runs first, and after any other order-0 SDK
+    /// callbacks. Restoration in OnPostprocessBuild runs at the same order.
+    ///
+    /// In Production mode this is a no-op.
+    /// </summary>
+    public class Yes2SDKBuildModeOverride : IPreprocessBuildWithReport, IPostprocessBuildWithReport
+    {
+        public int callbackOrder => 100;
+
+        private static WebGLExceptionSupport? s_savedExceptionSupport;
+
+        public void OnPreprocessBuild(BuildReport report)
+        {
+            if (report.summary.platform != BuildTarget.WebGL) return;
+
+            var mode = Yes2SDKBuildMode.Current;
+            if (mode == Yes2SDKBuildMode.Mode.Production)
+            {
+                s_savedExceptionSupport = null;
+                return;
+            }
+
+            WebGLExceptionSupport target = mode switch
+            {
+                Yes2SDKBuildMode.Mode.ProductionSafe => WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly,
+                Yes2SDKBuildMode.Mode.Diagnostic => WebGLExceptionSupport.FullWithStacktrace,
+                _ => PlayerSettings.WebGL.exceptionSupport,
+            };
+
+            s_savedExceptionSupport = PlayerSettings.WebGL.exceptionSupport;
+            PlayerSettings.WebGL.exceptionSupport = target;
+
+            Debug.Log(
+                $"[Yes2SDK] Build mode '{Yes2SDKBuildMode.DisplayName(mode)}' — " +
+                $"Exception Support overridden to {target} for this build only " +
+                $"(will restore to {s_savedExceptionSupport} after).");
+        }
+
+        public void OnPostprocessBuild(BuildReport report)
+        {
+            if (report.summary.platform != BuildTarget.WebGL) return;
+            if (!s_savedExceptionSupport.HasValue) return;
+
+            PlayerSettings.WebGL.exceptionSupport = s_savedExceptionSupport.Value;
+            s_savedExceptionSupport = null;
+        }
+    }
+}

--- a/Editor/Yes2SDKBuildModeOverride.cs
+++ b/Editor/Yes2SDKBuildModeOverride.cs
@@ -38,7 +38,7 @@ namespace Yes2SDK.Editor
 
     /// <summary>
     /// Build-time override that lets the user temporarily swap WebGL Exception
-    /// Support for a single build via the Build Window's Build Mode radio.
+    /// Support for a single build via the Build Window's Build Mode dropdown.
     /// Player Settings is restored after the build, so the user's persistent
     /// configuration isn't silently mutated.
     ///
@@ -46,24 +46,58 @@ namespace Yes2SDK.Editor
     /// guard's template check runs first, and after any other order-0 SDK
     /// callbacks. Restoration in OnPostprocessBuild runs at the same order.
     ///
+    /// Crash safety:
+    ///   The "saved" Player Settings value is persisted to EditorPrefs (not
+    ///   a static field) so that an Editor crash, force-quit, domain reload,
+    ///   or unhandled exception in another preprocess callback can't strand
+    ///   the user with a permanently-overridden ProjectSettings.asset value.
+    ///   An [InitializeOnLoadMethod] checks for stale state on Editor startup
+    ///   and restores from the persisted value if it finds one.
+    ///
     /// In Production mode this is a no-op.
     /// </summary>
     public class Yes2SDKBuildModeOverride : IPreprocessBuildWithReport, IPostprocessBuildWithReport
     {
         public int callbackOrder => 100;
 
-        private static WebGLExceptionSupport? s_savedExceptionSupport;
+        // The saved value persists across Editor sessions, so an interrupted
+        // build (crash, force-quit, domain reload mid-build, IPreprocess
+        // throw at higher callbackOrder) can still be recovered next launch.
+        private const string SavedExceptionSupportKey = "Yes2SDK.SavedExceptionSupport";
+
+        /// <summary>
+        /// Detects state left behind by a build that didn't complete its
+        /// postprocess callback (e.g., Editor crashed during a Diagnostic
+        /// build). Runs once per domain reload at Editor startup.
+        /// </summary>
+        [InitializeOnLoadMethod]
+        private static void RecoverInterruptedOverride()
+        {
+            if (!EditorPrefs.HasKey(SavedExceptionSupportKey)) return;
+
+            var saved = (WebGLExceptionSupport)EditorPrefs.GetInt(SavedExceptionSupportKey);
+            var current = PlayerSettings.WebGL.exceptionSupport;
+
+            // If saved == current, the postprocess ran and we just have a
+            // stale leftover key — clean it up silently.
+            if (saved != current)
+            {
+                Debug.LogWarning(
+                    "[Yes2SDK] Detected an interrupted build mode override " +
+                    $"from a previous session. Restoring Exception Support " +
+                    $"{current} -> {saved}. (If you intended {current}, edit " +
+                    "WebGL Settings in the Build Window now.)");
+                PlayerSettings.WebGL.exceptionSupport = saved;
+            }
+            EditorPrefs.DeleteKey(SavedExceptionSupportKey);
+        }
 
         public void OnPreprocessBuild(BuildReport report)
         {
             if (report.summary.platform != BuildTarget.WebGL) return;
 
             var mode = Yes2SDKBuildMode.Current;
-            if (mode == Yes2SDKBuildMode.Mode.Production)
-            {
-                s_savedExceptionSupport = null;
-                return;
-            }
+            if (mode == Yes2SDKBuildMode.Mode.Production) return;
 
             WebGLExceptionSupport target = mode switch
             {
@@ -72,22 +106,32 @@ namespace Yes2SDK.Editor
                 _ => PlayerSettings.WebGL.exceptionSupport,
             };
 
-            s_savedExceptionSupport = PlayerSettings.WebGL.exceptionSupport;
+            // If a previous build already saved a value (because postprocess
+            // didn't run yet or this is a re-entrant build), don't overwrite —
+            // the existing key holds the user's true original.
+            if (!EditorPrefs.HasKey(SavedExceptionSupportKey))
+            {
+                EditorPrefs.SetInt(SavedExceptionSupportKey, (int)PlayerSettings.WebGL.exceptionSupport);
+            }
             PlayerSettings.WebGL.exceptionSupport = target;
 
+            var saved = (WebGLExceptionSupport)EditorPrefs.GetInt(SavedExceptionSupportKey);
             Debug.Log(
                 $"[Yes2SDK] Build mode '{Yes2SDKBuildMode.DisplayName(mode)}' — " +
                 $"Exception Support overridden to {target} for this build only " +
-                $"(will restore to {s_savedExceptionSupport} after).");
+                $"(will restore to {saved} after).");
         }
 
         public void OnPostprocessBuild(BuildReport report)
         {
             if (report.summary.platform != BuildTarget.WebGL) return;
-            if (!s_savedExceptionSupport.HasValue) return;
+            if (!EditorPrefs.HasKey(SavedExceptionSupportKey)) return;
 
-            PlayerSettings.WebGL.exceptionSupport = s_savedExceptionSupport.Value;
-            s_savedExceptionSupport = null;
+            var saved = (WebGLExceptionSupport)EditorPrefs.GetInt(SavedExceptionSupportKey);
+            PlayerSettings.WebGL.exceptionSupport = saved;
+            EditorPrefs.DeleteKey(SavedExceptionSupportKey);
+
+            Debug.Log($"[Yes2SDK] Exception Support restored to {saved} after build.");
         }
     }
 }

--- a/Editor/Yes2SDKBuildModeOverride.cs.meta
+++ b/Editor/Yes2SDKBuildModeOverride.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7f0bc4e4611d64d1bb1bda09a8b9a90c

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -13,12 +13,14 @@ namespace Yes2SDK.Editor
     public class Yes2SDKWindow : EditorWindow
     {
         private const string PrefsBuildPath = "Yes2SDK_BuildPath";
+        private const string PrefsSettingsExpanded = "Yes2SDK_SettingsExpanded";
         private const string DashboardUrl = "https://dashboard.yes2games.com";
         private const string DocsUrl = "https://github.com/yes2games/yes2sdk-unity";
         private const string IssuesUrl = "https://github.com/yes2games/yes2sdk-unity/issues";
 
         private string _buildPath;
         private bool _isSetupComplete;
+        private bool _settingsExpanded;
 
         [MenuItem("Yes2SDK/Build Window", false, 0)]
         public static void ShowWindow()
@@ -37,6 +39,7 @@ namespace Yes2SDK.Editor
         private void OnEnable()
         {
             _buildPath = EditorPrefs.GetString(PrefsBuildPath, "Builds");
+            _settingsExpanded = EditorPrefs.GetBool(PrefsSettingsExpanded, false);
             RefreshSetupStatus();
         }
 
@@ -56,8 +59,20 @@ namespace Yes2SDK.Editor
             DrawStatus();
             EditorGUILayout.Space(10);
 
-            if (!_isSetupComplete) DrawSetup();
-            else DrawBuild();
+            if (!_isSetupComplete)
+            {
+                DrawSetup();
+            }
+            else
+            {
+                DrawSettings();
+                EditorGUILayout.Space(10);
+
+                DrawBuildMode();
+                EditorGUILayout.Space(10);
+
+                DrawBuild();
+            }
 
             GUILayout.FlexibleSpace();
             DrawLinks();
@@ -139,6 +154,156 @@ namespace Yes2SDK.Editor
             EditorGUILayout.EndVertical();
         }
 
+        private void DrawSettings()
+        {
+            // Collapsible — defaults closed so the Build Window stays compact
+            // for users who don't need to fiddle. Persists open/closed state
+            // across Editor sessions.
+            EditorGUI.BeginChangeCheck();
+            _settingsExpanded = EditorGUILayout.Foldout(
+                _settingsExpanded,
+                "WebGL Settings",
+                toggleOnLabelClick: true,
+                EditorStyles.foldoutHeader);
+            if (EditorGUI.EndChangeCheck())
+                EditorPrefs.SetBool(PrefsSettingsExpanded, _settingsExpanded);
+
+            if (!_settingsExpanded) return;
+
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+            EditorGUILayout.LabelField(
+                "Edits apply to Player Settings immediately — no Apply step.",
+                EditorStyles.miniLabel);
+            EditorGUILayout.Space(4);
+
+            // Template — informational only. BuildGuard enforces this; show a
+            // warning if it drifts.
+            string currentTemplate = PlayerSettings.WebGL.template;
+            string expected = "PROJECT:Yes2SDK-SuperSDK";
+            EditorGUILayout.LabelField(
+                new GUIContent("Template",
+                    "Yes2SDK-SuperSDK is required. Other templates won't have the JS bridge wired up — Yes2SDKBuildGuard will fail the build."),
+                new GUIContent(currentTemplate));
+            if (currentTemplate != expected)
+            {
+                EditorGUILayout.HelpBox(
+                    $"Template should be {expected}. Click \"Reset to recommended\" or set it via the Build Profile's Player Settings.",
+                    MessageType.Warning);
+            }
+
+            // Compression Format
+            EditorGUI.BeginChangeCheck();
+            var newCompression = (WebGLCompressionFormat)EditorGUILayout.EnumPopup(
+                new GUIContent("Compression",
+                    "Disabled is required for Yes2Games dashboard upload — the dashboard CDN doesn't currently send Content-Encoding headers, so Brotli/Gzip builds fail to decompress in browser."),
+                PlayerSettings.WebGL.compressionFormat);
+            if (EditorGUI.EndChangeCheck())
+                PlayerSettings.WebGL.compressionFormat = newCompression;
+
+            // Code Stripping
+            EditorGUI.BeginChangeCheck();
+            var currentStripping = PlayerSettings.GetManagedStrippingLevel(BuildTargetGroup.WebGL);
+            var newStripping = (ManagedStrippingLevel)EditorGUILayout.EnumPopup(
+                new GUIContent("Code Stripping",
+                    "Medium balances build size and AOT safety — recommended. High requires manual link.xml entries for reflection-only types. Low produces large builds; useful for debugging strip-related issues."),
+                currentStripping);
+            if (EditorGUI.EndChangeCheck())
+                PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, newStripping);
+
+            // Exception Support
+            EditorGUI.BeginChangeCheck();
+            var newException = (WebGLExceptionSupport)EditorGUILayout.EnumPopup(
+                new GUIContent("Exception Support",
+                    "Explicitly Thrown is recommended for most games — catches throws from Newtonsoft.Json and other libraries. None is smaller but breaks any try/catch path. Full With Stacktrace is largest; use only for diagnostics."),
+                PlayerSettings.WebGL.exceptionSupport);
+            if (EditorGUI.EndChangeCheck())
+                PlayerSettings.WebGL.exceptionSupport = newException;
+
+            // Initial Memory Size
+            EditorGUI.BeginChangeCheck();
+            int newMemory = EditorGUILayout.IntField(
+                new GUIContent("Memory Size (MB)",
+                    "Initial WebAssembly heap size. Most games need 256–512+ MB. Too small triggers a generic 'unspecified error' at boot when Unity can't allocate the heap."),
+                PlayerSettings.WebGL.initialMemorySize);
+            if (EditorGUI.EndChangeCheck())
+                PlayerSettings.WebGL.initialMemorySize = Mathf.Max(16, newMemory);
+
+            EditorGUILayout.Space(6);
+
+            // Reset button — only opt-in path back to BuildConfig.Default
+            // values. Was previously the auto-applied step on every build,
+            // which caused issue #40.
+            if (GUILayout.Button(
+                new GUIContent("Reset to recommended",
+                    "Reset all WebGL settings above to Yes2SDK's recommended values (Yes2SDK-SuperSDK template, Disabled compression, Medium stripping, Explicitly Thrown exceptions)."),
+                EditorStyles.miniButton))
+            {
+                ResetToRecommended();
+            }
+
+            EditorGUILayout.EndVertical();
+        }
+
+        private void DrawBuildMode()
+        {
+            EditorGUILayout.LabelField("Build Mode", EditorStyles.boldLabel);
+            EditorGUILayout.BeginVertical(EditorStyles.helpBox);
+
+            EditorGUILayout.LabelField(
+                "Override Exception Support for the next build only — Player Settings is restored after.",
+                EditorStyles.wordWrappedMiniLabel);
+            EditorGUILayout.Space(4);
+
+            // Dropdown — only one mode is active at a time, so a popup is
+            // more honest than a radio group and stays compact for users
+            // who never need to change it.
+            var current = Yes2SDKBuildMode.Current;
+            EditorGUI.BeginChangeCheck();
+            int newIndex = EditorGUILayout.Popup(
+                "Mode",
+                (int)current,
+                new[]
+                {
+                    "Production",
+                    "Production Safe (Explicitly Thrown)",
+                    "Diagnostic (Full With Stacktrace)",
+                });
+            if (EditorGUI.EndChangeCheck())
+            {
+                Yes2SDKBuildMode.Current = (Yes2SDKBuildMode.Mode)newIndex;
+            }
+
+            EditorGUILayout.Space(4);
+
+            // Detail block for the currently-selected mode — visible by
+            // default (no hover required), updates live as the user picks
+            // different modes from the dropdown.
+            string description = Yes2SDKBuildMode.Current switch
+            {
+                Yes2SDKBuildMode.Mode.Production =>
+                    "Use your Player Settings as-is. Pick this for shipping builds when " +
+                    "Exception Support is already set the way you want it (recommended " +
+                    "default: Explicitly Thrown — click \"Reset to recommended\" in " +
+                    "WebGL Settings above).",
+                Yes2SDKBuildMode.Mode.ProductionSafe =>
+                    "Force Exception Support → Explicitly Thrown for this build, restore " +
+                    "Player Settings after. Pick this when your Player Settings has " +
+                    "Exception Support: None but you still need to ship a build that " +
+                    "catches third-party throws (Newtonsoft.Json, i2 Localization, etc.). " +
+                    "About 10% larger than None — fine to ship.",
+                Yes2SDKBuildMode.Mode.Diagnostic =>
+                    "Force Exception Support → Full With Stacktrace for this build, " +
+                    "restore after. Pick this only while debugging — captures real C# " +
+                    "class/method names and line numbers in browser console errors. " +
+                    "About 30% larger — DO NOT ship Diagnostic builds to the dashboard.",
+                _ => string.Empty,
+            };
+
+            EditorGUILayout.LabelField(description, EditorStyles.wordWrappedMiniLabel);
+
+            EditorGUILayout.EndVertical();
+        }
+
         private void DrawBuild()
         {
             EditorGUILayout.LabelField("Build", EditorStyles.boldLabel);
@@ -179,10 +344,10 @@ namespace Yes2SDK.Editor
 
             EditorGUILayout.Space(6);
 
-            // Inline tertiary actions.
+            // Reinstall template — only tertiary action remaining; "Apply
+            // Settings" moved into the WebGL Settings foldout as
+            // "Reset to recommended".
             EditorGUILayout.BeginHorizontal();
-            if (GUILayout.Button("Apply Settings", EditorStyles.linkLabel))
-                ApplySettingsOnly();
             GUILayout.FlexibleSpace();
             if (GUILayout.Button("Reinstall Template", EditorStyles.linkLabel))
                 PerformSetup();
@@ -237,16 +402,14 @@ namespace Yes2SDK.Editor
             }
         }
 
-        private void ApplySettingsOnly()
+        private void ResetToRecommended()
         {
             BuildConfig.Default.ApplySettings();
-            Debug.Log("[Yes2SDK] Build settings applied (template, compression, stripping).");
+            Debug.Log("[Yes2SDK] WebGL settings reset to recommended values (template, compression, stripping, exception support).");
         }
 
         private void BuildGame(bool runAfterBuild)
         {
-            var config = BuildConfig.Default;
-
             if (!Yes2SDKInstaller.IsSetupComplete())
             {
                 EditorUtility.DisplayDialog("Yes2SDK",
@@ -254,7 +417,10 @@ namespace Yes2SDK.Editor
                 return;
             }
 
-            config.ApplySettings();
+            // No auto-apply of BuildConfig.Default here. Whatever the user has
+            // configured in Player Settings (or chosen via the Build Mode
+            // radio's IPreprocessBuildWithReport override) is what the build
+            // uses. Yes2SDKBuildGuard still enforces the template requirement.
 
             var scenes = EditorBuildSettings.scenes;
             if (scenes.Length == 0)

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 using UnityEditor;
 using System.IO;
+#if UNITY_6000_0_OR_NEWER
+using UnityEditor.Build.Profile;
+#endif
 
 namespace Yes2SDK.Editor
 {
@@ -172,8 +175,25 @@ namespace Yes2SDK.Editor
 
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
             EditorGUILayout.LabelField(
-                "Edits apply to Player Settings immediately — no Apply step.",
+                "Edits apply to project-wide Player Settings immediately — no Apply step.",
                 EditorStyles.miniLabel);
+
+#if UNITY_6000_0_OR_NEWER
+            // Unity 6 Build Profiles can override Player Settings on a
+            // per-profile basis. If one is active, edits made here might be
+            // shadowed at build time — warn the user explicitly so this isn't
+            // a silent footgun.
+            var activeProfile = BuildProfile.GetActiveBuildProfile();
+            if (activeProfile != null)
+            {
+                EditorGUILayout.HelpBox(
+                    $"Active Build Profile: \"{activeProfile.name}\".\n" +
+                    "If this profile has overrides for the WebGL settings below, " +
+                    "they will take precedence at build time. To edit the " +
+                    "profile's overrides instead, use File > Build Profiles.",
+                    MessageType.Info);
+            }
+#endif
             EditorGUILayout.Space(4);
 
             // Template — informational only. BuildGuard enforces this; show a
@@ -226,7 +246,11 @@ namespace Yes2SDK.Editor
                     "Initial WebAssembly heap size. Most games need 256–512+ MB. Too small triggers a generic 'unspecified error' at boot when Unity can't allocate the heap."),
                 PlayerSettings.WebGL.initialMemorySize);
             if (EditorGUI.EndChangeCheck())
-                PlayerSettings.WebGL.initialMemorySize = Mathf.Max(16, newMemory);
+                // Floor at 32 MB — Unity's empty-project default and a
+                // practical minimum for any real game. Lower values often
+                // trigger "unspecified error" at boot before Unity can even
+                // log a useful failure.
+                PlayerSettings.WebGL.initialMemorySize = Mathf.Max(32, newMemory);
 
             EditorGUILayout.Space(6);
 
@@ -253,16 +277,15 @@ namespace Yes2SDK.Editor
             // more honest than a radio group and stays compact for users
             // who never need to change it.
             var current = Yes2SDKBuildMode.Current;
+            // Build option labels from the enum + DisplayName helper so they
+            // never drift if the helper text changes.
+            var modes = (Yes2SDKBuildMode.Mode[])System.Enum.GetValues(typeof(Yes2SDKBuildMode.Mode));
+            var modeLabels = new string[modes.Length];
+            for (int i = 0; i < modes.Length; i++)
+                modeLabels[i] = Yes2SDKBuildMode.DisplayName(modes[i]);
+
             EditorGUI.BeginChangeCheck();
-            int newIndex = EditorGUILayout.Popup(
-                "Mode",
-                (int)current,
-                new[]
-                {
-                    "Production",
-                    "Production Safe (Explicitly Thrown)",
-                    "Diagnostic (Full With Stacktrace)",
-                });
+            int newIndex = EditorGUILayout.Popup("Mode", (int)current, modeLabels);
             if (EditorGUI.EndChangeCheck())
             {
                 Yes2SDKBuildMode.Current = (Yes2SDKBuildMode.Mode)newIndex;

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -249,11 +249,6 @@ namespace Yes2SDK.Editor
             EditorGUILayout.LabelField("Build Mode", EditorStyles.boldLabel);
             EditorGUILayout.BeginVertical(EditorStyles.helpBox);
 
-            EditorGUILayout.LabelField(
-                "Override Exception Support for the next build only — Player Settings is restored after.",
-                EditorStyles.wordWrappedMiniLabel);
-            EditorGUILayout.Space(4);
-
             // Dropdown — only one mode is active at a time, so a popup is
             // more honest than a radio group and stays compact for users
             // who never need to change it.

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ The output folder is what you upload to the **Yes2Games Dashboard** — the dash
 - **Unity 2021–2022**: *Edit > Project Settings > Player > WebGL* (project-wide).
 - **Unity 6+**: *File > Build Profiles* — select your WebGL profile, then click **Player Settings** at the bottom of the profile panel. Settings apply only to that profile.
 
-> Unity 6 moved WebGL settings from project-wide Player Settings into per-profile Build Profiles. The Yes2SDK Build Window's Settings panel reads/writes the active settings regardless of where they live, so it's the safest place to edit.
+> Unity 6 moved WebGL settings from project-wide Player Settings into per-profile Build Profiles. The Yes2SDK Build Window's Settings panel reads and writes the **project-wide** Player Settings. If you have an active Build Profile with overrides for these settings, the profile takes precedence at build time — edit those overrides via *File > Build Profiles*. The panel will surface a notice when an active profile is detected so you don't edit values that are then ignored.
 
 #### Build Mode for diagnostics
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 2. Click **Install Template** — this installs the `Yes2SDK-SuperSDK` WebGL template into your project
 3. The status indicator changes from "Setup Pending" to "Ready"
 
-> After updating the SDK package, click **Reinstall Template** in the Settings section to copy changes into your project.
+> After updating the SDK package, click **Reinstall Template** in the Build Window to copy changes into your project.
 
 ---
 
@@ -378,19 +378,37 @@ The output folder is what you upload to the **Yes2Games Dashboard** — the dash
 
 ### Build Configuration
 
-| Setting | Value |
-|---------|-------|
-| Template | Yes2SDK-SuperSDK |
-| Compression | Disabled |
-| Code Stripping | Medium |
-| Exception Support | None |
+| Setting | Recommended | Notes |
+|---|---|---|
+| Template | `Yes2SDK-SuperSDK` | Required. The build-time guard fails the build with any other template. |
+| Compression | Disabled | Required for dashboard upload — the CDN doesn't currently send `Content-Encoding` headers. |
+| Code Stripping | Medium | Balances build size and AOT safety. |
+| Exception Support | Explicitly Thrown Exceptions Only | See note below. |
+| Memory Size | 256 MB+ | Most games need at least 256–512 MB. Smaller heaps trigger a generic "unspecified error" at boot. |
 
-#### Where to set these — depends on your Unity version
+> ⚠️ **Why not `Exception Support: None`?**
+>
+> `None` produces the smallest build, but Unity WebGL's `None` mode strips exception infrastructure entirely — even an exception caught by a `try/catch` aborts the wasm. This breaks any code path where a dependency uses `try/catch` as control flow (Newtonsoft.Json — which the SDK itself imports — third-party Unity asset packages, save systems, etc.).
+>
+> Most games should ship with **Explicitly Thrown Exceptions Only**: about 10% larger build but compatible with the .NET ecosystem. Use `None` only after auditing your full dependency graph.
 
+#### Where to set these
+
+- **Yes2SDK Build Window** (recommended) — *Yes2SDK > Build Window > WebGL Settings* (collapsible panel). Edits write to Player Settings live, no Apply step. Click **Reset to recommended** to apply all the values from the table above at once.
 - **Unity 2021–2022**: *Edit > Project Settings > Player > WebGL* (project-wide).
-- **Unity 6+**: *File > Build Profiles* — select your WebGL profile, then click **Player Settings** at the bottom of the profile panel. Settings apply only to that profile, so make sure the profile you build is the one with these values.
+- **Unity 6+**: *File > Build Profiles* — select your WebGL profile, then click **Player Settings** at the bottom of the profile panel. Settings apply only to that profile.
 
-> Unity 6 moved WebGL settings from project-wide Player Settings into per-profile Build Profiles. If you set values in the old location on Unity 6+, the build will pick up the *profile's* defaults instead and your settings are silently ignored.
+> Unity 6 moved WebGL settings from project-wide Player Settings into per-profile Build Profiles. The Yes2SDK Build Window's Settings panel reads/writes the active settings regardless of where they live, so it's the safest place to edit.
+
+#### Build Mode for diagnostics
+
+The Build Window has a **Build Mode** dropdown for one-off overrides without changing your Player Settings:
+
+- **Production** — use Player Settings as-is. Default for shipping builds.
+- **Production Safe** — temporarily forces Exception Support to `Explicitly Thrown` for one build. Useful when your Player Settings is `None` but you need a build that catches third-party throws.
+- **Diagnostic** — temporarily forces `Full With Stacktrace`. Use to capture real C# class/method names in browser console errors when chasing a crash.
+
+The override saves and restores Player Settings around each build, so it never leaves your project in an unexpected state.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.2.0`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.3.0`
 4. Click **Add**
 
-> Pinning the URL with `#v2.2.0` keeps the package hash stable across resolves. Bump the tag (e.g. `#v2.2.0`) to upgrade. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.3.0` keeps the package hash stable across resolves. Bump the tag (e.g. `#v2.3.0`) to upgrade. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Yes2Log.cs.meta
+++ b/Runtime/Yes2Log.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7a8b9c0d1e2f3a4b5c6d7e8f9a0b1c2d
+guid: 88277f96830f48f69ea057d2a27ab302
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -68,7 +68,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.2.0";
+        public static string Version => "2.3.0";
 
         private static Yes2SDKAds _ads;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.2.0",
+    "version": "2.3.0",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
## Summary

Bundles four post-launch fixes from real-integrator feedback. All
changes ship together as **v2.3.0** — additive on the API surface
(no breaking changes), but with a behaviour change for users who
relied on the Build Window auto-applying settings.

Closes #39, #40, #41, #42.

## What's in this PR

### Fixed
- **#39 — `Yes2Log.cs.meta` GUID collision with `com.unity.ai.assistant`.**
  Meta file shipped with a hand-typed placeholder GUID that collided
  with the AI Assistant package's `AssemblyInfo.cs.meta`. Unity
  silently ignored one of the two, so projects using both packages
  failed to compile with `CS0103: Yes2Log does not exist`.
  Regenerated to a proper random GUID.
- **#42 — WebGL template `setLoadingProgress` log spam.**
  `index.html` forwarded every Unity progress callback tick to
  `window.Yes2SDK.setLoadingProgress`, which the dashboard inspector
  logged as "Loading progress" hundreds of times per build.
  Throttled to forward only when the integer percentage changes —
  at most 101 calls per build.

### Changed
- **#40 — Build Window no longer auto-overrides Player Settings on
  every build.** The previous version called
  `BuildConfig.Default.ApplySettings()` inside `BuildGame()`,
  silently resetting Exception Support / Compression / Stripping /
  Template each time the user clicked Build. The new Build Window
  has a collapsible **WebGL Settings** panel that inline-edits
  Player Settings (no Apply step) and a **Reset to recommended**
  button for opt-in re-apply. `Yes2SDKBuildGuard` still enforces
  the `Yes2SDK-SuperSDK` template — the only truly mandatory
  setting.
- **#40 — New `Build Mode` dropdown** with Production / Production
  Safe / Diagnostic options. Production Safe forces Exception
  Support to `Explicitly Thrown` for one build (useful when Player
  Settings is `None` but you need a build that catches third-party
  throws). Diagnostic forces `Full With Stacktrace` for one build.
  Both restore Player Settings after the build via
  `IPostprocessBuildWithReport`.
- **#41 — `BuildConfig.Default.exceptionSupport`** flipped from
  `None` → `ExplicitlyThrownExceptionsOnly`. `None` is smaller but
  breaks projects where a dependency uses `try/catch`
  (Newtonsoft.Json, etc.). The new default is ~10% larger but
  compatible with the .NET ecosystem.

### Documentation
- **#41 — README Build Configuration table** reworked: added
  Memory Size row, expanded Notes column, prominent warning
  explaining `None` vs `Explicitly Thrown`.
- New "Build Mode for diagnostics" subsection.
- "Where to set these" updated to lead with the Build Window's
  Settings panel (the safest place to edit because it bypasses
  the Unity-2021 vs Unity-6 Player Settings vs Build Profiles
  ambiguity).

## Behaviour notes for users on upgrade

- Existing builds will get `ExplicitlyThrownExceptionsOnly` for
  Exception Support unless overridden. About 10% larger build size,
  but compatible with libraries that use `try/catch` as control
  flow. To opt into the smaller `None` build, set Exception Support
  manually in the new WebGL Settings panel.
- The Build Window now respects custom Player Settings rather than
  silently overwriting them. Verify your active settings via
  *Yes2SDK > Build Window > WebGL Settings*.
- The `Apply Settings` link has been renamed **Reset to
  recommended** and moved into the WebGL Settings foldout.

## Verified

- [x] Yes2Log compiles cleanly with `com.unity.ai.assistant` installed
- [x] Build Window's WebGL Settings panel reads/writes Player
  Settings live
- [x] Build Mode: Production preserves user values across builds
- [x] Build Mode: Diagnostic temporarily overrides + restores after build
- [x] Throttle code is intact in the rendered WebGL template
  (verified by inspection); `window.Yes2SDK.setLoadingProgress`
  only exists on dashboard pages, so the volume reduction is
  observed automatically on next upload