### PR TITLE
chore: release v2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2026-05-29
+
+### Fixed
+- **`OnAudioEnabledChange` now reports the correct state under IL2CPP Code Stripping = High.** The `{ "enabled": ... }` payload from the JS bridge was being deserialized via Newtonsoft.Json, whose reflection-based deserializer can throw internally under aggressive stripping even with `link.xml` preservation. The exception was swallowed and the value defaulted to `true`, so mute toggles always surfaced as unmuted to the game. Replaced with a small manual parse so the value is preserved regardless of strip level. Required for YouTube cert (#14) on builds that ship with Code Stripping at High.
+
 ## [2.4.0] - 2026-05-05
 
 YouTube Playables certification readiness. Surfaces the lifecycle and audio-state APIs that YouTube cert reviewers test for. Required for any Unity game shipping to YouTube — without these, games cannot satisfy YouTube cert integration requirements #14, #21, and #22.

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.0`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.1`
 4. Click **Add**
 
-> Pinning the URL with `#v2.4.0` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.4.1` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.4.0",
+    "version": "2.4.1",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
## Summary
Patch release for the audio-enabled-change parse fix on `main` ([077ac64](../commit/077ac64)).

- `package.json`: 2.4.0 → 2.4.1
- `README.md`: pinned install URL bumped to `#v2.4.1`
- `CHANGELOG.md`: 2.4.1 entry added

## Release notes (2.4.1)

### Fixed
- **`OnAudioEnabledChange` now reports the correct state under IL2CPP Code Stripping = High.** The `{ "enabled": ... }` payload from the JS bridge was being deserialized via Newtonsoft.Json, whose reflection-based deserializer can throw internally under aggressive stripping even with `link.xml` preservation. The exception was swallowed and the value defaulted to `true`, so mute toggles always surfaced as unmuted to the game. Replaced with a small manual parse so the value is preserved regardless of strip level. Required for YouTube cert (#14) on builds that ship with Code Stripping at High.