### PR TITLE
fix(player): report real data/connected-players capability per platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.2] - 2026-06-10
+
+### Fixed
+- **`Player.IsDataSupported()` and `Player.IsConnectedPlayersSupported()` now report the real platform capability.** Both flags were hardcoded in C# to a CrazyGames-only check, which had drifted out of sync with the JS SDK. `IsDataSupported()` returned `false` on every platform except CrazyGames, so games that gate save/load on it skipped persistence on Yandex, YouTube, GameDistribution, and Poki — even though the SDK persists data on all of them (platform cloud save where available, local web storage otherwise). `IsConnectedPlayersSupported()` inversely returned `true` on CrazyGames, where the feature is not actually available. Both methods now delegate to the JS SDK so capability tracks the active platform adapter instead of being duplicated and stale.
+
+### Changed
+- **Player data save/load now works in the editor.** The editor/standalone mock for `Player.GetDataAsync` / `SetDataAsync` / `FlushDataAsync` previously returned `FeatureNotSupported`, which did not match the persistence the SDK provides in WebGL builds. The mock is now backed by `PlayerPrefs` (single merged JSON blob, same shape as the runtime store) and `IsDataSupported()` returns `true` in the editor, so save/load can be exercised in Play Mode without a WebGL build.
+
 ## [2.4.1] - 2026-05-29
 
 ### Fixed

--- a/Plugins/Yes2SDKPlayer.jslib
+++ b/Plugins/Yes2SDKPlayer.jslib
@@ -94,6 +94,18 @@ mergeInto(LibraryManager.library, {
                 SendMessage('Bridge', 'OnGetSignedPlayerInfoSuccess', typeof info === 'string' ? info : JSON.stringify(info));
             })
             .catch(__y2h.handleCatch('OnGetSignedPlayerInfoError', 'GetSignedPlayerInfo failed', 'Yes2SDK.Player.GetSignedPlayerInfoAsync'));
+    },
+
+    // Whether player data persistence is supported on the current platform
+    Yes2SDK_IsDataSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_IsDataSupportedJS: function() {
+        return (__y2h.has('player') && window.Yes2SDK.player.isDataSupported()) ? 1 : 0;
+    },
+
+    // Whether connected players are supported on the current platform
+    Yes2SDK_IsConnectedPlayersSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_IsConnectedPlayersSupportedJS: function() {
+        return (__y2h.has('player') && window.Yes2SDK.player.isConnectedPlayersSupported()) ? 1 : 0;
     }
 
 });

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.1`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.2`
 4. Click **Add**
 
-> Pinning the URL with `#v2.4.1` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.4.2` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Player/Yes2SDKPlayer.cs
+++ b/Runtime/Player/Yes2SDKPlayer.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using UnityEngine;
 
 namespace Yes2SDK
@@ -10,7 +11,10 @@ namespace Yes2SDK
     /// <summary>
     /// Player API for Yes2SDK.
     /// Provides player info, data persistence, connected players, and signed info.
-    /// On Poki, only GetPlayerAsync returns an anonymous player; all data operations return FeatureNotSupported.
+    /// Data persistence is available on every platform at runtime — platform cloud
+    /// save where the platform supports it, local web storage otherwise. Identity is
+    /// anonymous on platforms without an auth API (e.g. Poki, YouTube). Connected
+    /// players and signed info are platform-gated; check IsConnectedPlayersSupported().
     /// </summary>
     public class Yes2SDKPlayer
     {
@@ -51,6 +55,12 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_GetSignedPlayerInfoAsyncJS(string payload);
+
+        [DllImport("__Internal")]
+        private static extern int Yes2SDK_IsDataSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern int Yes2SDK_IsConnectedPlayersSupportedJS();
 #endif
 
         #endregion
@@ -76,7 +86,7 @@ namespace Yes2SDK
 
         /// <summary>
         /// Get player data for the specified keys.
-        /// On Poki, returns FeatureNotSupported.
+        /// Reads from platform cloud save where supported, local web storage otherwise.
         /// </summary>
         /// <param name="keys">Array of data keys to retrieve.</param>
         public void GetDataAsync(string[] keys, Action<string> onSuccess = null, Action<Error> onError = null)
@@ -88,14 +98,23 @@ namespace Yes2SDK
             var keysJson = JsonConvert.SerializeObject(keys);
             Yes2SDK_GetDataAsyncJS(keysJson);
 #else
-            Yes2Log.Log("Mock: GetDataAsync() — FeatureNotSupported");
-            InvokeGetDataError(FeatureNotSupportedError("Yes2SDK.Player.GetDataAsync"));
+            Yes2Log.Log("Mock: GetDataAsync() — reading from PlayerPrefs store");
+            var store = LoadMockStore();
+            var result = new JObject();
+            foreach (var key in keys)
+            {
+                if (store.TryGetValue(key, out var value))
+                {
+                    result[key] = value;
+                }
+            }
+            InvokeGetDataSuccess(result.ToString(Formatting.None));
 #endif
         }
 
         /// <summary>
         /// Set player data.
-        /// On Poki, returns FeatureNotSupported.
+        /// Writes to platform cloud save where supported, local web storage otherwise.
         /// </summary>
         /// <param name="dataJson">JSON string of key-value data to store.</param>
         public void SetDataAsync(string dataJson, Action onSuccess = null, Action<Error> onError = null)
@@ -106,14 +125,30 @@ namespace Yes2SDK
 #if UNITY_WEBGL && !UNITY_EDITOR
             Yes2SDK_SetDataAsyncJS(dataJson);
 #else
-            Yes2Log.Log("Mock: SetDataAsync() — FeatureNotSupported");
-            InvokeSetDataError(FeatureNotSupportedError("Yes2SDK.Player.SetDataAsync"));
+            Yes2Log.Log("Mock: SetDataAsync() — writing to PlayerPrefs store");
+            try
+            {
+                var store = LoadMockStore();
+                var incoming = string.IsNullOrEmpty(dataJson) ? new JObject() : JObject.Parse(dataJson);
+                store.Merge(incoming, new JsonMergeSettings { MergeArrayHandling = MergeArrayHandling.Replace });
+                SaveMockStore(store);
+                InvokeSetDataSuccess();
+            }
+            catch (Exception e)
+            {
+                InvokeSetDataError(new Error
+                {
+                    Code = "Unknown",
+                    Message = $"Failed to write mock player data: {e.Message}",
+                    Context = "Yes2SDK.Player.SetDataAsync"
+                });
+            }
 #endif
         }
 
         /// <summary>
         /// Flush (persist) all pending player data changes.
-        /// On Poki, returns FeatureNotSupported.
+        /// A no-op where writes already persist immediately (local web storage).
         /// </summary>
         public void FlushDataAsync(Action onSuccess = null, Action<Error> onError = null)
         {
@@ -123,8 +158,9 @@ namespace Yes2SDK
 #if UNITY_WEBGL && !UNITY_EDITOR
             Yes2SDK_FlushDataAsyncJS();
 #else
-            Yes2Log.Log("Mock: FlushDataAsync() — FeatureNotSupported");
-            InvokeFlushDataError(FeatureNotSupportedError("Yes2SDK.Player.FlushDataAsync"));
+            Yes2Log.Log("Mock: FlushDataAsync() — persisting PlayerPrefs store");
+            PlayerPrefs.Save();
+            InvokeFlushDataSuccess();
 #endif
         }
 
@@ -197,23 +233,27 @@ namespace Yes2SDK
 
         /// <summary>
         /// Whether player data persistence is supported on the current platform.
+        /// Delegates to the JS SDK so capability tracks the active platform adapter.
         /// </summary>
         public bool IsDataSupported()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            return Yes2SDK.CurrentPlatform == Platform.CrazyGames;
+            return Yes2SDK_IsDataSupportedJS() == 1;
 #else
-            return false;
+            // Editor/standalone mock persists via PlayerPrefs, mirroring the
+            // SDK's runtime guarantee that data is always persistable.
+            return true;
 #endif
         }
 
         /// <summary>
         /// Whether connected players are supported on the current platform.
+        /// Delegates to the JS SDK so capability tracks the active platform adapter.
         /// </summary>
         public bool IsConnectedPlayersSupported()
         {
 #if UNITY_WEBGL && !UNITY_EDITOR
-            return Yes2SDK.CurrentPlatform == Platform.CrazyGames;
+            return Yes2SDK_IsConnectedPlayersSupportedJS() == 1;
 #else
             return false;
 #endif
@@ -337,6 +377,31 @@ namespace Yes2SDK
                 Context = context
             };
         }
+
+#if !(UNITY_WEBGL && !UNITY_EDITOR)
+        // PlayerPrefs-backed store for the editor/standalone mock. Mirrors the
+        // WebGL behaviour (single merged JSON blob) so save/load can be tested
+        // in the editor instead of returning FeatureNotSupported.
+        private const string MockDataKey = "Yes2SDK.Player.MockData";
+
+        private static JObject LoadMockStore()
+        {
+            var raw = PlayerPrefs.GetString(MockDataKey, "{}");
+            try
+            {
+                return JObject.Parse(raw);
+            }
+            catch
+            {
+                return new JObject();
+            }
+        }
+
+        private static void SaveMockStore(JObject store)
+        {
+            PlayerPrefs.SetString(MockDataKey, store.ToString(Formatting.None));
+        }
+#endif
 
         #endregion
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
## Summary

`Player.IsDataSupported()` and `Player.IsConnectedPlayersSupported()` were hardcoded in C# to a CrazyGames-only check that had drifted from the JS SDK:

- `IsDataSupported()` returned `false` everywhere except CrazyGames, so games gating save/load on it skipped persistence on Yandex, YouTube, GameDistribution and Poki — even though the SDK persists data on all of them (platform cloud save where available, local web storage otherwise).
- `IsConnectedPlayersSupported()` inversely returned `true` on CrazyGames, where the feature is not available.

Both now delegate to the JS SDK via the player bridge, so capability tracks the active platform adapter instead of going stale.

## Changes

- [x] Add `Yes2SDK_IsDataSupportedJS` / `Yes2SDK_IsConnectedPlayersSupportedJS` bridges
- [x] `IsDataSupported()` / `IsConnectedPlayersSupported()` delegate to the bridge (return `false` in editor/non-WebGL as before)
- [x] Editor data mock now persists via `PlayerPrefs` (previously `FeatureNotSupported`), so save/load works in Play Mode and matches runtime
- [x] Correct stale docstrings that claimed data ops were unsupported
- [x] Bump 2.4.1 → 2.4.2 (package.json, README git-URL pin, CHANGELOG)

## Notes

Audited the other modules for the same drift: Auth/Banners/Score/Friends/Session already delegate to the JS bridge, Data has no capability flag, and the remaining stub modules correctly report unsupported. Player was the only module with a hardcoded platform check.