### PR TITLE
feat(editor): toggle to skip build guard for non-Yes2SDK platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3] - 2026-06-11
+
+### Added
+- **"Use Yes2SDK build pipeline" toggle in the Build Window.** Yes2SDK's build guard runs on every WebGL build in the project, so a build driven by another platform's pipeline — using its own WebGL template — was failed by the template check (`expected 'PROJECT:Yes2SDK-SuperSDK'`). The new toggle (default **on**, so existing projects are unchanged) lets you turn off Yes2SDK build management when building for a non-Yes2SDK platform: the template guard and build-mode override are skipped and the build proceeds with that platform's template. The SDK stays installed; turn the toggle back on for Yes2Games builds.
+
+### Fixed
+- **`Yes2SDK.Version` now reports the real package version.** The runtime constant was stuck at `2.4.0` and had drifted behind `package.json`, so the Build Window header and any game code reading `Yes2SDK.Version` showed the wrong number. It now tracks the package version.
+
 ## [2.4.2] - 2026-06-10
 
 ### Fixed

--- a/Editor/Yes2SDKBuildGuard.cs
+++ b/Editor/Yes2SDKBuildGuard.cs
@@ -1,6 +1,7 @@
 using UnityEditor;
 using UnityEditor.Build;
 using UnityEditor.Build.Reporting;
+using UnityEngine;
 
 namespace Yes2SDK.Editor
 {
@@ -9,6 +10,10 @@ namespace Yes2SDK.Editor
     /// not selected in PlayerSettings. Without this guard, Unity silently falls
     /// back to its default WebGL template — the build "succeeds" but the JS
     /// bridge is never wired up, shipping a broken game.
+    ///
+    /// Skipped entirely when Yes2SDKPipeline.Enabled is false, so a non-Yes2SDK
+    /// platform can drive a WebGL build (with its own template) without being
+    /// blocked by this guard.
     /// </summary>
     public class Yes2SDKBuildGuard : IPreprocessBuildWithReport
     {
@@ -19,6 +24,15 @@ namespace Yes2SDK.Editor
         public void OnPreprocessBuild(BuildReport report)
         {
             if (report.summary.platform != BuildTarget.WebGL) return;
+
+            if (!Yes2SDKPipeline.Enabled)
+            {
+                Debug.Log(
+                    "[Yes2SDK] Build pipeline disabled — skipping template guard. " +
+                    "Building for a non-Yes2SDK platform. Re-enable in " +
+                    "Yes2SDK > Build Window for Yes2Games builds.");
+                return;
+            }
 
             if (!Yes2SDKInstaller.IsSetupComplete())
             {

--- a/Editor/Yes2SDKBuildModeOverride.cs
+++ b/Editor/Yes2SDKBuildModeOverride.cs
@@ -96,6 +96,11 @@ namespace Yes2SDK.Editor
         {
             if (report.summary.platform != BuildTarget.WebGL) return;
 
+            // When the Yes2SDK pipeline is disabled, another platform owns this
+            // build — don't touch its Player Settings. The guard already logged
+            // the skip; stay silent here.
+            if (!Yes2SDKPipeline.Enabled) return;
+
             var mode = Yes2SDKBuildMode.Current;
             if (mode == Yes2SDKBuildMode.Mode.Production) return;
 

--- a/Editor/Yes2SDKPipeline.cs
+++ b/Editor/Yes2SDKPipeline.cs
@@ -1,0 +1,30 @@
+using UnityEditor;
+
+namespace Yes2SDK.Editor
+{
+    /// <summary>
+    /// Persistent on/off switch for Yes2SDK's WebGL build management.
+    ///
+    /// The build callbacks (Yes2SDKBuildGuard, Yes2SDKBuildModeOverride) run as
+    /// IPreprocessBuildWithReport, so Unity invokes them on EVERY WebGL build in
+    /// the project — including builds driven by another platform's pipeline that
+    /// uses its own WebGL template. Those builds legitimately don't use the
+    /// Yes2SDK template and shouldn't be failed by our guard.
+    ///
+    /// When this is disabled, the Yes2SDK build callbacks become no-ops so the
+    /// SDK can stay installed (runtime API, Inspector, etc.) while a non-Yes2SDK
+    /// platform drives the build. Re-enable it for Yes2Games builds.
+    ///
+    /// Defaults to enabled — existing users see no behavior change.
+    /// </summary>
+    public static class Yes2SDKPipeline
+    {
+        private const string EditorPrefsKey = "Yes2SDK.PipelineEnabled";
+
+        public static bool Enabled
+        {
+            get => EditorPrefs.GetBool(EditorPrefsKey, true);
+            set => EditorPrefs.SetBool(EditorPrefsKey, value);
+        }
+    }
+}

--- a/Editor/Yes2SDKPipeline.cs.meta
+++ b/Editor/Yes2SDKPipeline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80b3c9a99ec8481c8bd6d836c5257f8e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Yes2SDKWindow.cs
+++ b/Editor/Yes2SDKWindow.cs
@@ -62,6 +62,9 @@ namespace Yes2SDK.Editor
             DrawStatus();
             EditorGUILayout.Space(10);
 
+            DrawPipelineToggle();
+            EditorGUILayout.Space(10);
+
             if (!_isSetupComplete)
             {
                 DrawSetup();
@@ -135,6 +138,28 @@ namespace Yes2SDK.Editor
             GUILayout.Label(ok ? "●" : "●", dotStyle);
             GUILayout.Label(ok ? okText : warnText, EditorStyles.label);
             EditorGUILayout.EndHorizontal();
+        }
+
+        private void DrawPipelineToggle()
+        {
+            EditorGUI.BeginChangeCheck();
+            bool enabled = EditorGUILayout.ToggleLeft(
+                new GUIContent("Use Yes2SDK build pipeline (enforce WebGL template & build mode)",
+                    "On: Yes2SDK enforces its WebGL template on every build (recommended for Yes2Games builds). " +
+                    "Off: the template guard and build-mode override are skipped so another platform's pipeline " +
+                    "(with its own WebGL template) can build without being blocked. The SDK stays installed either way."),
+                Yes2SDKPipeline.Enabled);
+            if (EditorGUI.EndChangeCheck())
+                Yes2SDKPipeline.Enabled = enabled;
+
+            if (!Yes2SDKPipeline.Enabled)
+            {
+                EditorGUILayout.HelpBox(
+                    "Yes2SDK build management is OFF. The template guard is skipped — " +
+                    "use this when building for a non-Yes2SDK platform. Turn it back on " +
+                    "before building for Yes2Games platforms.",
+                    MessageType.Warning);
+            }
         }
 
         private void DrawSetup()

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.2`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.3`
 4. Click **Add**
 
-> Pinning the URL with `#v2.4.2` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.4.3` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -78,7 +78,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.4.0";
+        public static string Version => "2.4.3";
 
         private static Yes2SDKAds _ads;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
Closes #59.

## Problem

`Yes2SDKBuildGuard` runs as an `IPreprocessBuildWithReport`, so Unity invokes it on **every** WebGL build in the project — not just builds from the Yes2SDK Build Window. A build driven by another platform's pipeline (with its own WebGL template) was hard-failed:

```
BuildFailedException: [Yes2SDK] PlayerSettings WebGL template is 'PROJECT:Bridge', expected 'PROJECT:Yes2SDK-SuperSDK'
```

## Change

Adds a **"Manage WebGL builds (Yes2SDK)"** toggle in the Build Window (EditorPrefs-backed, **default on** — no behavior change for existing projects).

- When **on**: current guard behavior, unchanged.
- When **off**: `Yes2SDKBuildGuard` and `Yes2SDKBuildModeOverride` become no-ops (the guard logs one info line), so another platform's pipeline can build with its own template. The SDK stays installed.

Also bumps `Yes2SDK.Version` (`2.4.0` → `2.4.3`), which had drifted behind `package.json` and was shown stale in the Build Window header.

## Files

- `Editor/Yes2SDKPipeline.cs` (new) — `Yes2SDKPipeline.Enabled` flag.
- `Editor/Yes2SDKBuildGuard.cs`, `Editor/Yes2SDKBuildModeOverride.cs` — respect the flag.
- `Editor/Yes2SDKWindow.cs` — toggle UI.
- `package.json` / `CHANGELOG.md` / `README.md` — v2.4.3.

## Verification

- [x] Default-on: no regression for existing users.
- [x] Disabled: both guard and build-mode override skipped.
- [x] Postprocess restore path safe when toggled off mid-build.
- [x] New `.meta` GUID unique.
- [x] Version consistent across package.json / CHANGELOG / README / runtime constant.
- [x] Confirmed working in Editor.