### PR TITLE
Add Editor assembly definition to isolate editor scripts

### DIFF
--- a/Editor/Yes2SDK.Editor.asmdef
+++ b/Editor/Yes2SDK.Editor.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "Yes2SDK.Editor",
+    "rootNamespace": "Yes2SDK.Editor",
+    "references": [
+        "Yes2SDK.Runtime",
+        "Unity.Nuget.Newtonsoft-Json"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/Yes2SDK.Editor.asmdef.meta
+++ b/Editor/Yes2SDK.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 29b93b22b29e450c08cd00cdd75f8308
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add `Editor/Yes2SDK.Editor.asmdef` (+ .meta) so editor scripts compile into their own `Yes2SDK.Editor` assembly instead of the consumer game's `Assembly-CSharp-Editor`.
- References `Yes2SDK.Runtime` and `Unity.Nuget.Newtonsoft-Json`; `includePlatforms: ["Editor"]`.

Without an Editor asmdef, editor scripts land in the consumer's `Assembly-CSharp-Editor`. Inside `namespace Yes2SDK.Editor`, bare `Path`/`Environment` resolve against the global namespace before `using System.IO`/`System`, so a game class named `Path` or `Environment` shadows the BCL types and breaks compilation. Affected sites: `Yes2SDKInstaller.cs:22` (`Path.Combine`), `Yes2SDKKtx2Tool.cs:114,119` (`Environment.GetFolderPath`). The asmdef isolates the scripts into an assembly that does not contain the game's globals.

Ktx2 is accessed via reflection (no `#if YES2SDK_KTX`, no direct type reference), so no Ktx2 assembly reference or versionDefine is needed.

## Test plan
- Open the package in Unity 2021.3+; confirm `Yes2SDK.Editor.dll` compiles with no errors and the Build Window (`Yes2SDK > Build Window`) opens.
- In a consumer project that defines a global-namespace `Path` or `Environment` class, confirm editor scripts still compile.