### PR TITLE
feat: in-app purchases (Yes2SDK.IAP)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.0] - 2026-06-19
+## [2.4.5] - 2026-06-19
 
 ### Added
 - **In-app purchases.** `Yes2SDK.IAP` is now functional (previously a stub). `GetCatalogAsync`, `PurchaseAsync`, `GetPurchasesAsync`, and `ConsumePurchaseAsync` are wired through the SDK bridge to the platform payments API; results are delivered to the success callback as JSON. Call `GetPurchasesAsync` on launch so a returning player keeps the items they own. Supported on Yandex; `IsSupported()` reports availability for the active platform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - **In-app purchases.** `Yes2SDK.IAP` is now functional (previously a stub). `GetCatalogAsync`, `PurchaseAsync`, `GetPurchasesAsync`, and `ConsumePurchaseAsync` are wired through the SDK bridge to the platform payments API; results are delivered to the success callback as JSON. Call `GetPurchasesAsync` on launch so a returning player keeps the items they own. Supported on Yandex; `IsSupported()` reports availability for the active platform.
+- **Durable saves: `Yes2SDK.Data.FlushAsync()` and `Yes2SDK.Data.SetStringAsync()`.** The synchronous `Set*` calls are batched on cloud-backed platforms (Yandex debounces cloud writes), so a save made right before the game closes could be lost. `FlushAsync` forces all pending writes to the backing store and reports confirmation; `SetStringAsync` writes a single key and awaits it. Both provide callback and `Task` (CancellationToken) overloads — call `FlushAsync` at checkpoints to guarantee progress is persisted.
 
 ## [2.4.3] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-06-19
+
+### Added
+- **In-app purchases.** `Yes2SDK.IAP` is now functional (previously a stub). `GetCatalogAsync`, `PurchaseAsync`, `GetPurchasesAsync`, and `ConsumePurchaseAsync` are wired through the SDK bridge to the platform payments API; results are delivered to the success callback as JSON. Call `GetPurchasesAsync` on launch so a returning player keeps the items they own. Supported on Yandex; `IsSupported()` reports availability for the active platform.
+
 ## [2.4.3] - 2026-06-11
 
 ### Added

--- a/Plugins/Yes2SDKData.jslib
+++ b/Plugins/Yes2SDKData.jslib
@@ -70,6 +70,34 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_Data_DeleteAllJS: function() {
         if (__y2h.has('data')) { window.Yes2SDK.data.deleteAll(); return; }
         window.__y2.warn('Data module not loaded — ignoring deleteAll');
+    },
+
+    Yes2SDK_Data_SetStringAsyncJS__deps: ['$__y2', '$__y2h'],
+    Yes2SDK_Data_SetStringAsyncJS: function(keyPtr, valuePtr) {
+        if (!__y2h.has('data')) {
+            __y2h.sendError('OnDataSetStringError', 'NotInitialized', 'Yes2SDK Data module not loaded', 'Yes2SDK.Data.SetStringAsync');
+            return;
+        }
+        var key = UTF8ToString(keyPtr);
+        var value = UTF8ToString(valuePtr);
+        window.Yes2SDK.data.setStringAsync(key, value)
+            .then(function(ok) {
+                SendMessage('Bridge', 'OnDataSetStringSuccess', ok ? 'true' : 'false');
+            })
+            .catch(__y2h.handleCatch('OnDataSetStringError', 'SetStringAsync failed', 'Yes2SDK.Data.SetStringAsync'));
+    },
+
+    Yes2SDK_Data_FlushAsyncJS__deps: ['$__y2', '$__y2h'],
+    Yes2SDK_Data_FlushAsyncJS: function() {
+        if (!__y2h.has('data')) {
+            __y2h.sendError('OnDataFlushError', 'NotInitialized', 'Yes2SDK Data module not loaded', 'Yes2SDK.Data.FlushAsync');
+            return;
+        }
+        window.Yes2SDK.data.flushAsync()
+            .then(function(ok) {
+                SendMessage('Bridge', 'OnDataFlushSuccess', ok ? 'true' : 'false');
+            })
+            .catch(__y2h.handleCatch('OnDataFlushError', 'FlushAsync failed', 'Yes2SDK.Data.FlushAsync'));
     }
 
 });

--- a/Plugins/Yes2SDKIAP.jslib
+++ b/Plugins/Yes2SDKIAP.jslib
@@ -1,0 +1,71 @@
+mergeInto(LibraryManager.library, {
+
+    Yes2SDK_IAP_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_IAP_IsSupportedJS: function() {
+        return __y2h.has('iap') && window.Yes2SDK.iap.isSupported() ? 1 : 0;
+    },
+
+    Yes2SDK_IAP_GetCatalogAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_IAP_GetCatalogAsyncJS: function() {
+        if (!__y2h.has('iap')) {
+            __y2h.sendError('OnGetCatalogError', 'NotInitialized', 'Yes2SDK IAP module not loaded', 'Yes2SDK.IAP.GetCatalogAsync');
+            return;
+        }
+
+        window.Yes2SDK.iap.getCatalogAsync()
+            .then(function(products) {
+                SendMessage('Bridge', 'OnGetCatalogSuccess', JSON.stringify(products || []));
+            })
+            .catch(__y2h.handleCatch('OnGetCatalogError', 'GetCatalog failed', 'Yes2SDK.IAP.GetCatalogAsync'));
+    },
+
+    Yes2SDK_IAP_PurchaseAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_IAP_PurchaseAsyncJS: function(productIdPtr, developerPayloadPtr) {
+        if (!__y2h.has('iap')) {
+            __y2h.sendError('OnPurchaseError', 'NotInitialized', 'Yes2SDK IAP module not loaded', 'Yes2SDK.IAP.PurchaseAsync');
+            return;
+        }
+
+        var productId = UTF8ToString(productIdPtr);
+        var developerPayload = UTF8ToString(developerPayloadPtr);
+        var config = { productId: productId };
+        if (developerPayload) { config.developerPayload = developerPayload; }
+
+        window.Yes2SDK.iap.purchaseAsync(config)
+            .then(function(purchase) {
+                SendMessage('Bridge', 'OnPurchaseSuccess', JSON.stringify(purchase));
+            })
+            .catch(__y2h.handleCatch('OnPurchaseError', 'Purchase failed', 'Yes2SDK.IAP.PurchaseAsync'));
+    },
+
+    Yes2SDK_IAP_GetPurchasesAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_IAP_GetPurchasesAsyncJS: function() {
+        if (!__y2h.has('iap')) {
+            __y2h.sendError('OnGetPurchasesError', 'NotInitialized', 'Yes2SDK IAP module not loaded', 'Yes2SDK.IAP.GetPurchasesAsync');
+            return;
+        }
+
+        window.Yes2SDK.iap.getPurchasesAsync()
+            .then(function(purchases) {
+                SendMessage('Bridge', 'OnGetPurchasesSuccess', JSON.stringify(purchases || []));
+            })
+            .catch(__y2h.handleCatch('OnGetPurchasesError', 'GetPurchases failed', 'Yes2SDK.IAP.GetPurchasesAsync'));
+    },
+
+    Yes2SDK_IAP_ConsumePurchaseAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_IAP_ConsumePurchaseAsyncJS: function(purchaseTokenPtr) {
+        if (!__y2h.has('iap')) {
+            __y2h.sendError('OnConsumePurchaseError', 'NotInitialized', 'Yes2SDK IAP module not loaded', 'Yes2SDK.IAP.ConsumePurchaseAsync');
+            return;
+        }
+
+        var purchaseToken = UTF8ToString(purchaseTokenPtr);
+
+        window.Yes2SDK.iap.consumePurchaseAsync(purchaseToken)
+            .then(function() {
+                SendMessage('Bridge', 'OnConsumePurchaseSuccess', '');
+            })
+            .catch(__y2h.handleCatch('OnConsumePurchaseError', 'ConsumePurchase failed', 'Yes2SDK.IAP.ConsumePurchaseAsync'));
+    }
+
+});

--- a/Plugins/Yes2SDKIAP.jslib.meta
+++ b/Plugins/Yes2SDKIAP.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 7c4e1a9b2d6f48a3b1e0c5d7f9a2b6e4
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.3`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.5.0`
 4. Click **Add**
 
-> Pinning the URL with `#v2.4.3` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.5.0` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.5.0`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.5`
 4. Click **Add**
 
-> Pinning the URL with `#v2.5.0` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.4.5` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Bridge.cs
+++ b/Runtime/Bridge.cs
@@ -107,6 +107,10 @@ namespace Yes2SDK
             ["OnPurchaseSuccess"] = Yes2SDKIAP.InvokePurchaseSuccess,
             ["OnGetPurchasesSuccess"] = Yes2SDKIAP.InvokeGetPurchasesSuccess,
             ["OnConsumePurchaseSuccess"] = _ => Yes2SDKIAP.InvokeConsumePurchaseSuccess(),
+
+            // Data (async durable saves)
+            ["OnDataSetStringSuccess"] = Yes2SDKData.InvokeSetStringAsyncSuccess,
+            ["OnDataFlushSuccess"] = Yes2SDKData.InvokeFlushSuccess,
         };
 
         // Error handlers — receive parsed Error struct
@@ -153,6 +157,10 @@ namespace Yes2SDK
             ["OnPurchaseError"] = Yes2SDKIAP.InvokePurchaseError,
             ["OnGetPurchasesError"] = Yes2SDKIAP.InvokeGetPurchasesError,
             ["OnConsumePurchaseError"] = Yes2SDKIAP.InvokeConsumePurchaseError,
+
+            // Data (async durable saves)
+            ["OnDataSetStringError"] = Yes2SDKData.InvokeSetStringAsyncError,
+            ["OnDataFlushError"] = Yes2SDKData.InvokeFlushError,
         };
 
         #endregion
@@ -243,6 +251,12 @@ namespace Yes2SDK
         public void OnGetPurchasesError(string msg) => Handle(msg);
         public void OnConsumePurchaseSuccess(string msg) => Handle(msg);
         public void OnConsumePurchaseError(string msg) => Handle(msg);
+
+        // Data (async durable saves)
+        public void OnDataSetStringSuccess(string msg) => Handle(msg);
+        public void OnDataSetStringError(string msg) => Handle(msg);
+        public void OnDataFlushSuccess(string msg) => Handle(msg);
+        public void OnDataFlushError(string msg) => Handle(msg);
 
         #endregion
 

--- a/Runtime/Bridge.cs
+++ b/Runtime/Bridge.cs
@@ -101,6 +101,12 @@ namespace Yes2SDK
 
             // Friends
             ["OnListFriendsSuccess"] = Yes2SDKFriends.InvokeListFriendsSuccess,
+
+            // IAP
+            ["OnGetCatalogSuccess"] = Yes2SDKIAP.InvokeGetCatalogSuccess,
+            ["OnPurchaseSuccess"] = Yes2SDKIAP.InvokePurchaseSuccess,
+            ["OnGetPurchasesSuccess"] = Yes2SDKIAP.InvokeGetPurchasesSuccess,
+            ["OnConsumePurchaseSuccess"] = _ => Yes2SDKIAP.InvokeConsumePurchaseSuccess(),
         };
 
         // Error handlers — receive parsed Error struct
@@ -141,6 +147,12 @@ namespace Yes2SDK
 
             // Friends
             ["OnListFriendsError"] = Yes2SDKFriends.InvokeListFriendsError,
+
+            // IAP
+            ["OnGetCatalogError"] = Yes2SDKIAP.InvokeGetCatalogError,
+            ["OnPurchaseError"] = Yes2SDKIAP.InvokePurchaseError,
+            ["OnGetPurchasesError"] = Yes2SDKIAP.InvokeGetPurchasesError,
+            ["OnConsumePurchaseError"] = Yes2SDKIAP.InvokeConsumePurchaseError,
         };
 
         #endregion
@@ -221,6 +233,16 @@ namespace Yes2SDK
         // Friends
         public void OnListFriendsSuccess(string msg) => Handle(msg);
         public void OnListFriendsError(string msg) => Handle(msg);
+
+        // IAP
+        public void OnGetCatalogSuccess(string msg) => Handle(msg);
+        public void OnGetCatalogError(string msg) => Handle(msg);
+        public void OnPurchaseSuccess(string msg) => Handle(msg);
+        public void OnPurchaseError(string msg) => Handle(msg);
+        public void OnGetPurchasesSuccess(string msg) => Handle(msg);
+        public void OnGetPurchasesError(string msg) => Handle(msg);
+        public void OnConsumePurchaseSuccess(string msg) => Handle(msg);
+        public void OnConsumePurchaseError(string msg) => Handle(msg);
 
         #endregion
 

--- a/Runtime/Data/Yes2SDKData.cs
+++ b/Runtime/Data/Yes2SDKData.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
 using UnityEngine;
 
 namespace Yes2SDK
@@ -39,7 +42,22 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_Data_DeleteAllJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Data_SetStringAsyncJS(string key, string value);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Data_FlushAsyncJS();
 #endif
+
+        #endregion
+
+        #region Async Callback Fields
+
+        private static Action<bool> _setStringAsyncSuccessCallback;
+        private static Action<Error> _setStringAsyncErrorCallback;
+        private static Action<bool> _flushSuccessCallback;
+        private static Action<Error> _flushErrorCallback;
 
         #endregion
 
@@ -156,6 +174,93 @@ namespace Yes2SDK
             PlayerPrefs.DeleteAll();
             PlayerPrefs.Save();
 #endif
+        }
+
+        #endregion
+
+        #region Async Public API (durable saves)
+
+        /// <summary>
+        /// Set a string value and await platform confirmation. On cloud-backed
+        /// platforms (e.g. Yandex) onSuccess fires only after the write is
+        /// confirmed; the bool reports success.
+        /// </summary>
+        public void SetStringAsync(string key, string value, Action<bool> onSuccess = null, Action<Error> onError = null)
+        {
+            _setStringAsyncSuccessCallback = onSuccess;
+            _setStringAsyncErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Data_SetStringAsyncJS(key, value);
+#else
+            PlayerPrefs.SetString(key, value);
+            PlayerPrefs.Save();
+            InvokeSetStringAsyncSuccess("true");
+#endif
+        }
+
+        /// <summary>
+        /// Force any pending/batched writes to the platform's backing store and
+        /// await confirmation. Synchronous setters may be batched (Yandex
+        /// debounces cloud writes), so call this at a checkpoint — or before the
+        /// game may close — to guarantee progress is persisted.
+        /// </summary>
+        public void FlushAsync(Action<bool> onSuccess = null, Action<Error> onError = null)
+        {
+            _flushSuccessCallback = onSuccess;
+            _flushErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Data_FlushAsyncJS();
+#else
+            // PlayerPrefs writes are already durable in the editor.
+            PlayerPrefs.Save();
+            InvokeFlushSuccess("true");
+#endif
+        }
+
+        /// <summary>Task overload of <see cref="SetStringAsync(string,string,Action{bool},Action{Error})"/>.</summary>
+        public Task<bool> SetStringAsync(string key, string value, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<bool>(
+                (success, error) => SetStringAsync(key, value, success, error),
+                cancellationToken);
+
+        /// <summary>Task overload of <see cref="FlushAsync(Action{bool},Action{Error})"/>.</summary>
+        public Task<bool> FlushAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<bool>(
+                (success, error) => FlushAsync(success, error),
+                cancellationToken);
+
+        #endregion
+
+        #region Async Callback Invocations (called by Bridge)
+
+        internal static void InvokeSetStringAsyncSuccess(string result)
+        {
+            _setStringAsyncSuccessCallback?.Invoke(result == "true" || result == "1");
+            _setStringAsyncSuccessCallback = null;
+            _setStringAsyncErrorCallback = null;
+        }
+
+        internal static void InvokeSetStringAsyncError(Error error)
+        {
+            _setStringAsyncErrorCallback?.Invoke(error);
+            _setStringAsyncSuccessCallback = null;
+            _setStringAsyncErrorCallback = null;
+        }
+
+        internal static void InvokeFlushSuccess(string result)
+        {
+            _flushSuccessCallback?.Invoke(result == "true" || result == "1");
+            _flushSuccessCallback = null;
+            _flushErrorCallback = null;
+        }
+
+        internal static void InvokeFlushError(Error error)
+        {
+            _flushErrorCallback?.Invoke(error);
+            _flushSuccessCallback = null;
+            _flushErrorCallback = null;
         }
 
         #endregion

--- a/Runtime/IAP/Yes2SDKIAP.cs
+++ b/Runtime/IAP/Yes2SDKIAP.cs
@@ -1,26 +1,212 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Yes2SDK
 {
     /// <summary>
     /// In-App Purchase API for Yes2SDK.
-    /// Currently a stub — returns FeatureNotSupported on all platforms.
+    /// Backed by the platform payments API via the Core SDK (window.Yes2SDK.iap).
+    /// On Yandex this maps to the Yandex Payments API (catalog, purchase, restore,
+    /// consume). Result payloads are delivered to onSuccess as JSON strings.
     /// </summary>
-    public class Yes2SDKIAP : Yes2SDKStubModule
+    public class Yes2SDKIAP
     {
-        protected override string FeatureName => "IAP";
-        protected override string ModuleName => "IAP";
+        #region Static Callback Fields
 
+        private static Action<string> _getCatalogSuccessCallback;
+        private static Action<Error> _getCatalogErrorCallback;
+        private static Action<string> _purchaseSuccessCallback;
+        private static Action<Error> _purchaseErrorCallback;
+        private static Action<string> _getPurchasesSuccessCallback;
+        private static Action<Error> _getPurchasesErrorCallback;
+        private static Action _consumeSuccessCallback;
+        private static Action<Error> _consumeErrorCallback;
+
+        #endregion
+
+        #region JavaScript Imports
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_IAP_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_IAP_GetCatalogAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_IAP_PurchaseAsyncJS(string productId, string developerPayload);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_IAP_GetPurchasesAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_IAP_ConsumePurchaseAsyncJS(string purchaseToken);
+#endif
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether in-app purchases are supported on the current platform.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_IAP_IsSupportedJS();
+#else
+            Yes2Log.Log("Mock: IAP.IsSupported() — returning false");
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Get the product catalog. onSuccess receives a JSON array of products.
+        /// </summary>
         public void GetCatalogAsync(Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetCatalogAsync));
+        {
+            _getCatalogSuccessCallback = onSuccess;
+            _getCatalogErrorCallback = onError;
 
-        public void PurchaseAsync(string productId, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(PurchaseAsync), productId);
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_IAP_GetCatalogAsyncJS();
+#else
+            Yes2Log.Log("Mock: IAP.GetCatalogAsync() — returning empty catalog");
+            InvokeGetCatalogSuccess("[]");
+#endif
+        }
 
+        /// <summary>
+        /// Initiate a purchase. onSuccess receives the purchase as a JSON object.
+        /// </summary>
+        /// <param name="productId">Product identifier to purchase.</param>
+        /// <param name="onSuccess">Called with the purchase JSON on success.</param>
+        /// <param name="onError">Called with an error on failure or cancellation.</param>
+        /// <param name="developerPayload">Optional payload echoed back on the purchase.</param>
+        public void PurchaseAsync(
+            string productId,
+            Action<string> onSuccess = null,
+            Action<Error> onError = null,
+            string developerPayload = null)
+        {
+            _purchaseSuccessCallback = onSuccess;
+            _purchaseErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_IAP_PurchaseAsyncJS(productId, developerPayload ?? string.Empty);
+#else
+            Yes2Log.Log($"Mock: IAP.PurchaseAsync('{productId}') — FeatureNotSupported");
+            InvokePurchaseError(FeatureNotSupportedError("Yes2SDK.IAP.PurchaseAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Restore the player's purchases. onSuccess receives a JSON array of
+        /// purchases — call this on launch so returning players keep what they own.
+        /// </summary>
         public void GetPurchasesAsync(Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetPurchasesAsync));
+        {
+            _getPurchasesSuccessCallback = onSuccess;
+            _getPurchasesErrorCallback = onError;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_IAP_GetPurchasesAsyncJS();
+#else
+            Yes2Log.Log("Mock: IAP.GetPurchasesAsync() — returning empty list");
+            InvokeGetPurchasesSuccess("[]");
+#endif
+        }
+
+        /// <summary>
+        /// Consume a purchase (for consumable products) so it can be bought again.
+        /// </summary>
         public void ConsumePurchaseAsync(string purchaseToken, Action onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(ConsumePurchaseAsync), purchaseToken);
+        {
+            _consumeSuccessCallback = onSuccess;
+            _consumeErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_IAP_ConsumePurchaseAsyncJS(purchaseToken);
+#else
+            Yes2Log.Log($"Mock: IAP.ConsumePurchaseAsync('{purchaseToken}') — success");
+            InvokeConsumePurchaseSuccess();
+#endif
+        }
+
+        #endregion
+
+        #region Internal Callback Invocations (called by Bridge)
+
+        internal static void InvokeGetCatalogSuccess(string catalogJson)
+        {
+            _getCatalogSuccessCallback?.Invoke(catalogJson);
+            _getCatalogSuccessCallback = null;
+            _getCatalogErrorCallback = null;
+        }
+
+        internal static void InvokeGetCatalogError(Error error)
+        {
+            _getCatalogErrorCallback?.Invoke(error);
+            _getCatalogSuccessCallback = null;
+            _getCatalogErrorCallback = null;
+        }
+
+        internal static void InvokePurchaseSuccess(string purchaseJson)
+        {
+            _purchaseSuccessCallback?.Invoke(purchaseJson);
+            _purchaseSuccessCallback = null;
+            _purchaseErrorCallback = null;
+        }
+
+        internal static void InvokePurchaseError(Error error)
+        {
+            _purchaseErrorCallback?.Invoke(error);
+            _purchaseSuccessCallback = null;
+            _purchaseErrorCallback = null;
+        }
+
+        internal static void InvokeGetPurchasesSuccess(string purchasesJson)
+        {
+            _getPurchasesSuccessCallback?.Invoke(purchasesJson);
+            _getPurchasesSuccessCallback = null;
+            _getPurchasesErrorCallback = null;
+        }
+
+        internal static void InvokeGetPurchasesError(Error error)
+        {
+            _getPurchasesErrorCallback?.Invoke(error);
+            _getPurchasesSuccessCallback = null;
+            _getPurchasesErrorCallback = null;
+        }
+
+        internal static void InvokeConsumePurchaseSuccess()
+        {
+            _consumeSuccessCallback?.Invoke();
+            _consumeSuccessCallback = null;
+            _consumeErrorCallback = null;
+        }
+
+        internal static void InvokeConsumePurchaseError(Error error)
+        {
+            _consumeErrorCallback?.Invoke(error);
+            _consumeSuccessCallback = null;
+            _consumeErrorCallback = null;
+        }
+
+        #endregion
+
+        #region Private Helpers
+
+        private static Error FeatureNotSupportedError(string context)
+        {
+            return new Error
+            {
+                Code = "FeatureNotSupported",
+                Message = "This feature is not supported on the current platform",
+                Context = context
+            };
+        }
+
+        #endregion
     }
 }

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -78,7 +78,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.4.3";
+        public static string Version => "2.5.0";
 
         private static Yes2SDKAds _ads;
 

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -78,7 +78,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.5.0";
+        public static string Version => "2.4.5";
 
         private static Yes2SDKAds _ads;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.4.3",
+    "version": "2.5.0",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.5.0",
+    "version": "2.4.5",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
## What

Makes `Yes2SDK.IAP` functional. It was previously a stub that returned `FeatureNotSupported` for every call.

## Changes

- New `Plugins/Yes2SDKIAP.jslib` delegates to `window.Yes2SDK.iap` (the Core SDK payments API).
- `Yes2SDKIAP` C# now bridges: `GetCatalogAsync`, `PurchaseAsync`, `GetPurchasesAsync`, `ConsumePurchaseAsync` (+ `IsSupported`). Results arrive on the success callback as JSON.
- `Bridge` dispatches the IAP success/error callbacks.
- Editor mock: empty catalog/purchases, `PurchaseAsync` reports `FeatureNotSupported`.
- Bumped to **2.5.0** (package.json, runtime `Version`, README install pins).

## Notes

- Call `GetPurchasesAsync` on launch so returning players keep the items they own.
- Supported on Yandex today; `IsSupported()` reports per-platform availability.

## Verification

No Unity compile CI in this repo — needs a compile + Play Mode check in the editor before merge. Logic mirrors the existing `Yes2SDKAuth` async-bridge pattern.