### PR TITLE
feat: leaderboard, stats, config, review modules + player/session APIs (v2.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-06-24
+
+### Added
+- **Leaderboards.** `Yes2SDK.Leaderboard` is now functional (previously a stub). `GetLeaderboardAsync`, `SetScoreAsync`, `GetEntriesAsync`, and `GetPlayerEntryAsync` are wired through the SDK bridge; results are delivered to the success callback as JSON. Supported on Yandex; `IsSupported()` reports availability for the active platform.
+- **Player stats.** `Yes2SDK.Stats` is now functional (previously a stub). `GetStatsAsync`, `SetStatsAsync`, and `IncrementStatsAsync` manage server-side numeric counters. Supported on Yandex.
+- **Remote config: `Yes2SDK.Config`.** `GetFlagsAsync` fetches platform feature flags as a string→string map, with optional defaults; on platforms without remote config it returns the defaults you pass so the same code runs everywhere.
+- **Rating prompt: `Yes2SDK.Review`.** `CanReviewAsync` checks eligibility and `RequestReviewAsync` shows the platform's in-game rating prompt (Yandex). `RequestReviewAsync` checks eligibility internally first, so it is safe to call directly; it no-ops gracefully where unsupported.
+- **Player identity.** `Yes2SDK.Player` adds `GetUniqueIdAsync`, `GetIDsPerGameAsync`, `GetPayingStatusAsync`, `GetModeAsync`, and `GetPhotoAsync(size)`.
+- **Banner status: `Yes2SDK.Banners.GetBannerStatusAsync()`** reports whether a sticky banner is currently showing.
+- **Server time: `Yes2SDK.Game.GetServerTimeAsync()`** returns tamper-proof server time where available, falling back to local device time otherwise.
+- **Device info: `Yes2SDK.Session.GetDeviceInfo()`** returns the device type and form-factor flags (mobile / desktop / tablet / TV) synchronously.
+
+### Changed
+- **`Leaderboard.SetScoreAsync` success callback now returns the resulting entry as JSON** (rank and score after submission), previously parameterless.
+
 ## [2.4.5] - 2026-06-19
 
 ### Added

--- a/Plugins/Yes2SDKBanners.jslib
+++ b/Plugins/Yes2SDKBanners.jslib
@@ -38,6 +38,20 @@ mergeInto(LibraryManager.library, {
         if (!__y2h.has('banners')) return false;
         try { return window.Yes2SDK.banners.isSupported() ? 1 : 0; }
         catch (e) { return 0; }
+    },
+
+    Yes2SDK_Banners_GetBannerStatusAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Banners_GetBannerStatusAsyncJS: function() {
+        if (!__y2h.has('banners')) {
+            __y2h.sendError('OnGetBannerStatusError', 'NotInitialized', 'Yes2SDK Banners module not loaded', 'Yes2SDK.Banners.GetBannerStatusAsync');
+            return;
+        }
+
+        window.Yes2SDK.banners.getBannerStatusAsync()
+            .then(function(status) {
+                SendMessage('Bridge', 'OnGetBannerStatusSuccess', JSON.stringify(status || { isShowing: false }));
+            })
+            .catch(__y2h.handleCatch('OnGetBannerStatusError', 'GetBannerStatus failed', 'Yes2SDK.Banners.GetBannerStatusAsync'));
     }
 
 });

--- a/Plugins/Yes2SDKConfig.jslib
+++ b/Plugins/Yes2SDKConfig.jslib
@@ -1,0 +1,26 @@
+mergeInto(LibraryManager.library, {
+
+    Yes2SDK_Config_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Config_IsSupportedJS: function() {
+        return __y2h.has('config') && window.Yes2SDK.config.isSupported() ? 1 : 0;
+    },
+
+    Yes2SDK_Config_GetFlagsAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Config_GetFlagsAsyncJS: function(optionsJsonPtr) {
+        if (!__y2h.has('config')) {
+            __y2h.sendError('OnGetFlagsError', 'NotInitialized', 'Yes2SDK Config module not loaded', 'Yes2SDK.Config.GetFlagsAsync');
+            return;
+        }
+
+        var options;
+        try { options = JSON.parse(UTF8ToString(optionsJsonPtr)) || {}; }
+        catch (e) { options = {}; }
+
+        window.Yes2SDK.config.getFlagsAsync(options)
+            .then(function(flags) {
+                SendMessage('Bridge', 'OnGetFlagsSuccess', JSON.stringify(flags || {}));
+            })
+            .catch(__y2h.handleCatch('OnGetFlagsError', 'GetFlags failed', 'Yes2SDK.Config.GetFlagsAsync'));
+    }
+
+});

--- a/Plugins/Yes2SDKConfig.jslib.meta
+++ b/Plugins/Yes2SDKConfig.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: a3e7f1c92b6d48f0a51c8e2d7b4f9c63
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Plugins/Yes2SDKGame.jslib
+++ b/Plugins/Yes2SDKGame.jslib
@@ -61,6 +61,20 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_Game_CopyToClipboardJS: function(textPtr) {
         var text = UTF8ToString(textPtr);
         if (__y2h.has('game')) window.Yes2SDK.game.copyToClipboard(text);
+    },
+
+    Yes2SDK_Game_GetServerTimeAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Game_GetServerTimeAsyncJS: function() {
+        if (!__y2h.has('game')) {
+            __y2h.sendError('OnGetServerTimeError', 'NotInitialized', 'Yes2SDK Game module not loaded', 'Yes2SDK.Game.GetServerTimeAsync');
+            return;
+        }
+
+        window.Yes2SDK.game.getServerTimeAsync()
+            .then(function(time) {
+                SendMessage('Bridge', 'OnGetServerTimeSuccess', String(time));
+            })
+            .catch(__y2h.handleCatch('OnGetServerTimeError', 'GetServerTime failed', 'Yes2SDK.Game.GetServerTimeAsync'));
     }
 
 });

--- a/Plugins/Yes2SDKLeaderboard.jslib
+++ b/Plugins/Yes2SDKLeaderboard.jslib
@@ -1,0 +1,89 @@
+mergeInto(LibraryManager.library, {
+
+    Yes2SDK_Leaderboard_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_IsSupportedJS: function() {
+        return __y2h.has('leaderboard') && window.Yes2SDK.leaderboard.isSupported() ? 1 : 0;
+    },
+
+    Yes2SDK_Leaderboard_GetLeaderboardAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_GetLeaderboardAsyncJS: function(namePtr) {
+        if (!__y2h.has('leaderboard')) {
+            __y2h.sendError('OnGetLeaderboardError', 'NotInitialized', 'Yes2SDK Leaderboard module not loaded', 'Yes2SDK.Leaderboard.GetLeaderboardAsync');
+            return;
+        }
+
+        var name = UTF8ToString(namePtr);
+
+        window.Yes2SDK.leaderboard.getLeaderboardAsync(name)
+            .then(function(leaderboard) {
+                SendMessage('Bridge', 'OnGetLeaderboardSuccess', JSON.stringify(leaderboard));
+            })
+            .catch(__y2h.handleCatch('OnGetLeaderboardError', 'GetLeaderboard failed', 'Yes2SDK.Leaderboard.GetLeaderboardAsync'));
+    },
+
+    Yes2SDK_Leaderboard_SetScoreAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_SetScoreAsyncJS: function(namePtr, score, metadataPtr) {
+        if (!__y2h.has('leaderboard')) {
+            __y2h.sendError('OnSetScoreError', 'NotInitialized', 'Yes2SDK Leaderboard module not loaded', 'Yes2SDK.Leaderboard.SetScoreAsync');
+            return;
+        }
+
+        var name = UTF8ToString(namePtr);
+        var metadata = UTF8ToString(metadataPtr);
+
+        window.Yes2SDK.leaderboard.setScoreAsync(name, score, metadata || undefined)
+            .then(function(entry) {
+                SendMessage('Bridge', 'OnSetScoreSuccess', JSON.stringify(entry));
+            })
+            .catch(__y2h.handleCatch('OnSetScoreError', 'SetScore failed', 'Yes2SDK.Leaderboard.SetScoreAsync'));
+    },
+
+    Yes2SDK_Leaderboard_GetEntriesAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_GetEntriesAsyncJS: function(namePtr, count, offset) {
+        if (!__y2h.has('leaderboard')) {
+            __y2h.sendError('OnGetEntriesError', 'NotInitialized', 'Yes2SDK Leaderboard module not loaded', 'Yes2SDK.Leaderboard.GetEntriesAsync');
+            return;
+        }
+
+        var name = UTF8ToString(namePtr);
+
+        window.Yes2SDK.leaderboard.getEntriesAsync(name, count, offset)
+            .then(function(entries) {
+                SendMessage('Bridge', 'OnGetEntriesSuccess', JSON.stringify(entries || []));
+            })
+            .catch(__y2h.handleCatch('OnGetEntriesError', 'GetEntries failed', 'Yes2SDK.Leaderboard.GetEntriesAsync'));
+    },
+
+    Yes2SDK_Leaderboard_GetPlayerEntryAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_GetPlayerEntryAsyncJS: function(namePtr) {
+        if (!__y2h.has('leaderboard')) {
+            __y2h.sendError('OnGetPlayerEntryError', 'NotInitialized', 'Yes2SDK Leaderboard module not loaded', 'Yes2SDK.Leaderboard.GetPlayerEntryAsync');
+            return;
+        }
+
+        var name = UTF8ToString(namePtr);
+
+        window.Yes2SDK.leaderboard.getPlayerEntryAsync(name)
+            .then(function(entry) {
+                SendMessage('Bridge', 'OnGetPlayerEntrySuccess', JSON.stringify(entry === undefined ? null : entry));
+            })
+            .catch(__y2h.handleCatch('OnGetPlayerEntryError', 'GetPlayerEntry failed', 'Yes2SDK.Leaderboard.GetPlayerEntryAsync'));
+    },
+
+    Yes2SDK_Leaderboard_GetConnectedPlayerEntriesAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Leaderboard_GetConnectedPlayerEntriesAsyncJS: function(namePtr, count, offset) {
+        if (!__y2h.has('leaderboard')) {
+            __y2h.sendError('OnGetConnectedPlayerEntriesError', 'NotInitialized', 'Yes2SDK Leaderboard module not loaded', 'Yes2SDK.Leaderboard.GetConnectedPlayerEntriesAsync');
+            return;
+        }
+
+        var name = UTF8ToString(namePtr);
+
+        window.Yes2SDK.leaderboard.getConnectedPlayerEntriesAsync(name, count, offset)
+            .then(function(entries) {
+                SendMessage('Bridge', 'OnGetConnectedPlayerEntriesSuccess', JSON.stringify(entries || []));
+            })
+            .catch(__y2h.handleCatch('OnGetConnectedPlayerEntriesError', 'GetConnectedPlayerEntries failed', 'Yes2SDK.Leaderboard.GetConnectedPlayerEntriesAsync'));
+    }
+
+});

--- a/Plugins/Yes2SDKLeaderboard.jslib.meta
+++ b/Plugins/Yes2SDKLeaderboard.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: b2f8c4a1e6d34f97a05b1c3d7e9f2a8c
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Plugins/Yes2SDKPlayer.jslib
+++ b/Plugins/Yes2SDKPlayer.jslib
@@ -106,6 +106,83 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_IsConnectedPlayersSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IsConnectedPlayersSupportedJS: function() {
         return (__y2h.has('player') && window.Yes2SDK.player.isConnectedPlayersSupported()) ? 1 : 0;
+    },
+
+    // Get a stable unique player id
+    Yes2SDK_Player_GetUniqueIdAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Player_GetUniqueIdAsyncJS: function() {
+        if (!__y2h.has('player')) {
+            __y2h.sendError('OnGetUniqueIdError', 'NotInitialized', 'Yes2SDK Player module not loaded', 'Yes2SDK.Player.GetUniqueIdAsync');
+            return;
+        }
+
+        window.Yes2SDK.player.getUniqueId()
+            .then(function(id) {
+                SendMessage('Bridge', 'OnGetUniqueIdSuccess', id || '');
+            })
+            .catch(__y2h.handleCatch('OnGetUniqueIdError', 'GetUniqueId failed', 'Yes2SDK.Player.GetUniqueIdAsync'));
+    },
+
+    // Get the player's cross-game identities
+    Yes2SDK_Player_GetIDsPerGameAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Player_GetIDsPerGameAsyncJS: function() {
+        if (!__y2h.has('player')) {
+            __y2h.sendError('OnGetIDsPerGameError', 'NotInitialized', 'Yes2SDK Player module not loaded', 'Yes2SDK.Player.GetIDsPerGameAsync');
+            return;
+        }
+
+        window.Yes2SDK.player.getIDsPerGame()
+            .then(function(ids) {
+                SendMessage('Bridge', 'OnGetIDsPerGameSuccess', JSON.stringify(ids || []));
+            })
+            .catch(__y2h.handleCatch('OnGetIDsPerGameError', 'GetIDsPerGame failed', 'Yes2SDK.Player.GetIDsPerGameAsync'));
+    },
+
+    // Get the player's paying status
+    Yes2SDK_Player_GetPayingStatusAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Player_GetPayingStatusAsyncJS: function() {
+        if (!__y2h.has('player')) {
+            __y2h.sendError('OnGetPayingStatusError', 'NotInitialized', 'Yes2SDK Player module not loaded', 'Yes2SDK.Player.GetPayingStatusAsync');
+            return;
+        }
+
+        window.Yes2SDK.player.getPayingStatus()
+            .then(function(status) {
+                SendMessage('Bridge', 'OnGetPayingStatusSuccess', status || 'unknown');
+            })
+            .catch(__y2h.handleCatch('OnGetPayingStatusError', 'GetPayingStatus failed', 'Yes2SDK.Player.GetPayingStatusAsync'));
+    },
+
+    // Get the player's session mode
+    Yes2SDK_Player_GetModeAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Player_GetModeAsyncJS: function() {
+        if (!__y2h.has('player')) {
+            __y2h.sendError('OnGetModeError', 'NotInitialized', 'Yes2SDK Player module not loaded', 'Yes2SDK.Player.GetModeAsync');
+            return;
+        }
+
+        window.Yes2SDK.player.getMode()
+            .then(function(mode) {
+                SendMessage('Bridge', 'OnGetModeSuccess', mode || 'unknown');
+            })
+            .catch(__y2h.handleCatch('OnGetModeError', 'GetMode failed', 'Yes2SDK.Player.GetModeAsync'));
+    },
+
+    // Get the player's avatar URL for the requested size
+    Yes2SDK_Player_GetPhotoAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Player_GetPhotoAsyncJS: function(sizePtr) {
+        if (!__y2h.has('player')) {
+            __y2h.sendError('OnGetPhotoError', 'NotInitialized', 'Yes2SDK Player module not loaded', 'Yes2SDK.Player.GetPhotoAsync');
+            return;
+        }
+
+        var size = UTF8ToString(sizePtr);
+
+        window.Yes2SDK.player.getPhoto(size || undefined)
+            .then(function(photo) {
+                SendMessage('Bridge', 'OnGetPhotoSuccess', (photo === null || photo === undefined) ? 'null' : photo);
+            })
+            .catch(__y2h.handleCatch('OnGetPhotoError', 'GetPhoto failed', 'Yes2SDK.Player.GetPhotoAsync'));
     }
 
 });

--- a/Plugins/Yes2SDKReview.jslib
+++ b/Plugins/Yes2SDKReview.jslib
@@ -1,0 +1,36 @@
+mergeInto(LibraryManager.library, {
+
+    Yes2SDK_Review_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Review_IsSupportedJS: function() {
+        return __y2h.has('review') && window.Yes2SDK.review.isSupported() ? 1 : 0;
+    },
+
+    Yes2SDK_Review_CanReviewAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Review_CanReviewAsyncJS: function() {
+        if (!__y2h.has('review')) {
+            __y2h.sendError('OnCanReviewError', 'NotInitialized', 'Yes2SDK Review module not loaded', 'Yes2SDK.Review.CanReviewAsync');
+            return;
+        }
+
+        window.Yes2SDK.review.canReviewAsync()
+            .then(function(eligibility) {
+                SendMessage('Bridge', 'OnCanReviewSuccess', JSON.stringify(eligibility || { canReview: false }));
+            })
+            .catch(__y2h.handleCatch('OnCanReviewError', 'CanReview failed', 'Yes2SDK.Review.CanReviewAsync'));
+    },
+
+    Yes2SDK_Review_RequestReviewAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Review_RequestReviewAsyncJS: function() {
+        if (!__y2h.has('review')) {
+            __y2h.sendError('OnRequestReviewError', 'NotInitialized', 'Yes2SDK Review module not loaded', 'Yes2SDK.Review.RequestReviewAsync');
+            return;
+        }
+
+        window.Yes2SDK.review.requestReviewAsync()
+            .then(function(result) {
+                SendMessage('Bridge', 'OnRequestReviewSuccess', JSON.stringify(result || { feedbackSent: false }));
+            })
+            .catch(__y2h.handleCatch('OnRequestReviewError', 'RequestReview failed', 'Yes2SDK.Review.RequestReviewAsync'));
+    }
+
+});

--- a/Plugins/Yes2SDKReview.jslib.meta
+++ b/Plugins/Yes2SDKReview.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: e8b2d6a4f1c93e75b08a2f6c4d1e7b95
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Plugins/Yes2SDKSession.jslib
+++ b/Plugins/Yes2SDKSession.jslib
@@ -81,6 +81,18 @@ mergeInto(LibraryManager.library, {
             }
         } catch (e) {}
         return 1;
+    },
+
+    // Get detailed device info synchronously as a JSON string
+    Yes2SDK_GetDeviceInfoJS__deps: ['$__y2h'],
+    Yes2SDK_GetDeviceInfoJS: function() {
+        var json = '{"type":"unknown","isMobile":false,"isDesktop":false,"isTablet":false,"isTV":false}';
+        try {
+            if (__y2h.has('session') && typeof window.Yes2SDK.session.getDeviceInfo === 'function') {
+                json = JSON.stringify(window.Yes2SDK.session.getDeviceInfo());
+            }
+        } catch (e) {}
+        return __y2h.returnStr(json);
     }
 
 });

--- a/Plugins/Yes2SDKStats.jslib
+++ b/Plugins/Yes2SDKStats.jslib
@@ -1,0 +1,62 @@
+mergeInto(LibraryManager.library, {
+
+    Yes2SDK_Stats_IsSupportedJS__deps: ['$__y2h'],
+    Yes2SDK_Stats_IsSupportedJS: function() {
+        return __y2h.has('stats') && window.Yes2SDK.stats.isSupported() ? 1 : 0;
+    },
+
+    Yes2SDK_Stats_GetStatsAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Stats_GetStatsAsyncJS: function(keysJsonPtr) {
+        if (!__y2h.has('stats')) {
+            __y2h.sendError('OnGetStatsError', 'NotInitialized', 'Yes2SDK Stats module not loaded', 'Yes2SDK.Stats.GetStatsAsync');
+            return;
+        }
+
+        var keys;
+        try { keys = JSON.parse(UTF8ToString(keysJsonPtr)) || []; }
+        catch (e) { keys = []; }
+
+        window.Yes2SDK.stats.getStatsAsync(keys)
+            .then(function(stats) {
+                SendMessage('Bridge', 'OnGetStatsSuccess', JSON.stringify(stats || {}));
+            })
+            .catch(__y2h.handleCatch('OnGetStatsError', 'GetStats failed', 'Yes2SDK.Stats.GetStatsAsync'));
+    },
+
+    Yes2SDK_Stats_SetStatsAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Stats_SetStatsAsyncJS: function(statsJsonPtr) {
+        if (!__y2h.has('stats')) {
+            __y2h.sendError('OnSetStatsError', 'NotInitialized', 'Yes2SDK Stats module not loaded', 'Yes2SDK.Stats.SetStatsAsync');
+            return;
+        }
+
+        var stats;
+        try { stats = JSON.parse(UTF8ToString(statsJsonPtr)) || {}; }
+        catch (e) { stats = {}; }
+
+        window.Yes2SDK.stats.setStatsAsync(stats)
+            .then(function() {
+                SendMessage('Bridge', 'OnSetStatsSuccess', '');
+            })
+            .catch(__y2h.handleCatch('OnSetStatsError', 'SetStats failed', 'Yes2SDK.Stats.SetStatsAsync'));
+    },
+
+    Yes2SDK_Stats_IncrementStatsAsyncJS__deps: ['$__y2h'],
+    Yes2SDK_Stats_IncrementStatsAsyncJS: function(incrementsJsonPtr) {
+        if (!__y2h.has('stats')) {
+            __y2h.sendError('OnIncrementStatsError', 'NotInitialized', 'Yes2SDK Stats module not loaded', 'Yes2SDK.Stats.IncrementStatsAsync');
+            return;
+        }
+
+        var increments;
+        try { increments = JSON.parse(UTF8ToString(incrementsJsonPtr)) || {}; }
+        catch (e) { increments = {}; }
+
+        window.Yes2SDK.stats.incrementStatsAsync(increments)
+            .then(function(stats) {
+                SendMessage('Bridge', 'OnIncrementStatsSuccess', JSON.stringify(stats || {}));
+            })
+            .catch(__y2h.handleCatch('OnIncrementStatsError', 'IncrementStats failed', 'Yes2SDK.Stats.IncrementStatsAsync'));
+    }
+
+});

--- a/Plugins/Yes2SDKStats.jslib.meta
+++ b/Plugins/Yes2SDKStats.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: d4a1f7b3c9e8425a6b0d2f5c1a7e3b9d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any:
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.4.5`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.5.0`
 4. Click **Add**
 
-> Pinning the URL with `#v2.4.5` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.5.0` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Banners/Yes2SDKBanners.cs
+++ b/Runtime/Banners/Yes2SDKBanners.cs
@@ -14,6 +14,8 @@ namespace Yes2SDK
 
         private static Action _bannerRequestSuccessCallback;
         private static Action<Error> _bannerRequestErrorCallback;
+        private static Action<string> _bannerStatusSuccessCallback;
+        private static Action<Error> _bannerStatusErrorCallback;
 
         #endregion
 
@@ -34,6 +36,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern bool Yes2SDK_Banners_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Banners_GetBannerStatusAsyncJS();
 #endif
 
         #endregion
@@ -109,6 +114,23 @@ namespace Yes2SDK
 #endif
         }
 
+        /// <summary>
+        /// Get the current banner status. onSuccess receives a JSON object
+        /// { isShowing, reason? }.
+        /// </summary>
+        public void GetBannerStatusAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _bannerStatusSuccessCallback = onSuccess;
+            _bannerStatusErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Banners_GetBannerStatusAsyncJS();
+#else
+            Yes2Log.Log("Mock: Banners.GetBannerStatusAsync() — returning isShowing=false");
+            InvokeBannerStatusSuccess("{\"isShowing\":false}");
+#endif
+        }
+
         #endregion
 
         #region Internal Callback Invocations (called by Bridge)
@@ -125,6 +147,20 @@ namespace Yes2SDK
             _bannerRequestErrorCallback?.Invoke(error);
             _bannerRequestSuccessCallback = null;
             _bannerRequestErrorCallback = null;
+        }
+
+        internal static void InvokeBannerStatusSuccess(string statusJson)
+        {
+            _bannerStatusSuccessCallback?.Invoke(statusJson);
+            _bannerStatusSuccessCallback = null;
+            _bannerStatusErrorCallback = null;
+        }
+
+        internal static void InvokeBannerStatusError(Error error)
+        {
+            _bannerStatusErrorCallback?.Invoke(error);
+            _bannerStatusSuccessCallback = null;
+            _bannerStatusErrorCallback = null;
         }
 
         #endregion

--- a/Runtime/Bridge.cs
+++ b/Runtime/Bridge.cs
@@ -85,6 +85,11 @@ namespace Yes2SDK
             ["OnFlushDataSuccess"] = _ => Yes2SDKPlayer.InvokeFlushDataSuccess(),
             ["OnGetConnectedPlayersSuccess"] = Yes2SDKPlayer.InvokeGetConnectedPlayersSuccess,
             ["OnGetSignedPlayerInfoSuccess"] = Yes2SDKPlayer.InvokeGetSignedPlayerInfoSuccess,
+            ["OnGetUniqueIdSuccess"] = Yes2SDKPlayer.InvokeGetUniqueIdSuccess,
+            ["OnGetIDsPerGameSuccess"] = Yes2SDKPlayer.InvokeGetIDsPerGameSuccess,
+            ["OnGetPayingStatusSuccess"] = Yes2SDKPlayer.InvokeGetPayingStatusSuccess,
+            ["OnGetModeSuccess"] = Yes2SDKPlayer.InvokeGetModeSuccess,
+            ["OnGetPhotoSuccess"] = Yes2SDKPlayer.InvokeGetPhotoSuccess,
 
             // Auth
             ["OnGetCurrentUserSuccess"] = Yes2SDKAuth.InvokeGetCurrentUserSuccess,
@@ -95,9 +100,11 @@ namespace Yes2SDK
             // Game
             ["OnInviteLinkSuccess"] = Yes2SDKGame.InvokeInviteLinkSuccess,
             ["OnSettingsChanged"] = Yes2SDKGame.InvokeSettingsChanged,
+            ["OnGetServerTimeSuccess"] = Yes2SDKGame.InvokeGetServerTimeSuccess,
 
             // Banners
             ["OnBannerRequestSuccess"] = _ => Yes2SDKBanners.InvokeBannerRequestSuccess(),
+            ["OnGetBannerStatusSuccess"] = Yes2SDKBanners.InvokeBannerStatusSuccess,
 
             // Friends
             ["OnListFriendsSuccess"] = Yes2SDKFriends.InvokeListFriendsSuccess,
@@ -111,6 +118,25 @@ namespace Yes2SDK
             // Data (async durable saves)
             ["OnDataSetStringSuccess"] = Yes2SDKData.InvokeSetStringAsyncSuccess,
             ["OnDataFlushSuccess"] = Yes2SDKData.InvokeFlushSuccess,
+
+            // Leaderboard
+            ["OnGetLeaderboardSuccess"] = Yes2SDKLeaderboard.InvokeGetLeaderboardSuccess,
+            ["OnSetScoreSuccess"] = Yes2SDKLeaderboard.InvokeSetScoreSuccess,
+            ["OnGetEntriesSuccess"] = Yes2SDKLeaderboard.InvokeGetEntriesSuccess,
+            ["OnGetPlayerEntrySuccess"] = Yes2SDKLeaderboard.InvokeGetPlayerEntrySuccess,
+            ["OnGetConnectedPlayerEntriesSuccess"] = Yes2SDKLeaderboard.InvokeGetConnectedPlayerEntriesSuccess,
+
+            // Stats
+            ["OnGetStatsSuccess"] = Yes2SDKStats.InvokeGetStatsSuccess,
+            ["OnSetStatsSuccess"] = _ => Yes2SDKStats.InvokeSetStatsSuccess(),
+            ["OnIncrementStatsSuccess"] = Yes2SDKStats.InvokeIncrementStatsSuccess,
+
+            // Config
+            ["OnGetFlagsSuccess"] = Yes2SDKConfig.InvokeGetFlagsSuccess,
+
+            // Review
+            ["OnCanReviewSuccess"] = Yes2SDKReview.InvokeCanReviewSuccess,
+            ["OnRequestReviewSuccess"] = Yes2SDKReview.InvokeRequestReviewSuccess,
         };
 
         // Error handlers — receive parsed Error struct
@@ -136,6 +162,11 @@ namespace Yes2SDK
             ["OnFlushDataError"] = Yes2SDKPlayer.InvokeFlushDataError,
             ["OnGetConnectedPlayersError"] = Yes2SDKPlayer.InvokeGetConnectedPlayersError,
             ["OnGetSignedPlayerInfoError"] = Yes2SDKPlayer.InvokeGetSignedPlayerInfoError,
+            ["OnGetUniqueIdError"] = Yes2SDKPlayer.InvokeGetUniqueIdError,
+            ["OnGetIDsPerGameError"] = Yes2SDKPlayer.InvokeGetIDsPerGameError,
+            ["OnGetPayingStatusError"] = Yes2SDKPlayer.InvokeGetPayingStatusError,
+            ["OnGetModeError"] = Yes2SDKPlayer.InvokeGetModeError,
+            ["OnGetPhotoError"] = Yes2SDKPlayer.InvokeGetPhotoError,
 
             // Auth
             ["OnGetCurrentUserError"] = Yes2SDKAuth.InvokeGetCurrentUserError,
@@ -145,9 +176,11 @@ namespace Yes2SDK
 
             // Game
             ["OnInviteLinkError"] = Yes2SDKGame.InvokeInviteLinkError,
+            ["OnGetServerTimeError"] = Yes2SDKGame.InvokeGetServerTimeError,
 
             // Banners
             ["OnBannerRequestError"] = Yes2SDKBanners.InvokeBannerRequestError,
+            ["OnGetBannerStatusError"] = Yes2SDKBanners.InvokeBannerStatusError,
 
             // Friends
             ["OnListFriendsError"] = Yes2SDKFriends.InvokeListFriendsError,
@@ -161,6 +194,25 @@ namespace Yes2SDK
             // Data (async durable saves)
             ["OnDataSetStringError"] = Yes2SDKData.InvokeSetStringAsyncError,
             ["OnDataFlushError"] = Yes2SDKData.InvokeFlushError,
+
+            // Leaderboard
+            ["OnGetLeaderboardError"] = Yes2SDKLeaderboard.InvokeGetLeaderboardError,
+            ["OnSetScoreError"] = Yes2SDKLeaderboard.InvokeSetScoreError,
+            ["OnGetEntriesError"] = Yes2SDKLeaderboard.InvokeGetEntriesError,
+            ["OnGetPlayerEntryError"] = Yes2SDKLeaderboard.InvokeGetPlayerEntryError,
+            ["OnGetConnectedPlayerEntriesError"] = Yes2SDKLeaderboard.InvokeGetConnectedPlayerEntriesError,
+
+            // Stats
+            ["OnGetStatsError"] = Yes2SDKStats.InvokeGetStatsError,
+            ["OnSetStatsError"] = Yes2SDKStats.InvokeSetStatsError,
+            ["OnIncrementStatsError"] = Yes2SDKStats.InvokeIncrementStatsError,
+
+            // Config
+            ["OnGetFlagsError"] = Yes2SDKConfig.InvokeGetFlagsError,
+
+            // Review
+            ["OnCanReviewError"] = Yes2SDKReview.InvokeCanReviewError,
+            ["OnRequestReviewError"] = Yes2SDKReview.InvokeRequestReviewError,
         };
 
         #endregion
@@ -218,6 +270,16 @@ namespace Yes2SDK
         public void OnGetConnectedPlayersError(string msg) => Handle(msg);
         public void OnGetSignedPlayerInfoSuccess(string msg) => Handle(msg);
         public void OnGetSignedPlayerInfoError(string msg) => Handle(msg);
+        public void OnGetUniqueIdSuccess(string msg) => Handle(msg);
+        public void OnGetUniqueIdError(string msg) => Handle(msg);
+        public void OnGetIDsPerGameSuccess(string msg) => Handle(msg);
+        public void OnGetIDsPerGameError(string msg) => Handle(msg);
+        public void OnGetPayingStatusSuccess(string msg) => Handle(msg);
+        public void OnGetPayingStatusError(string msg) => Handle(msg);
+        public void OnGetModeSuccess(string msg) => Handle(msg);
+        public void OnGetModeError(string msg) => Handle(msg);
+        public void OnGetPhotoSuccess(string msg) => Handle(msg);
+        public void OnGetPhotoError(string msg) => Handle(msg);
 
         // Auth
         public void OnGetCurrentUserSuccess(string msg) => Handle(msg);
@@ -233,10 +295,14 @@ namespace Yes2SDK
         public void OnInviteLinkSuccess(string msg) => Handle(msg);
         public void OnInviteLinkError(string msg) => Handle(msg);
         public void OnSettingsChanged(string msg) => Handle(msg);
+        public void OnGetServerTimeSuccess(string msg) => Handle(msg);
+        public void OnGetServerTimeError(string msg) => Handle(msg);
 
         // Banners
         public void OnBannerRequestSuccess(string msg) => Handle(msg);
         public void OnBannerRequestError(string msg) => Handle(msg);
+        public void OnGetBannerStatusSuccess(string msg) => Handle(msg);
+        public void OnGetBannerStatusError(string msg) => Handle(msg);
 
         // Friends
         public void OnListFriendsSuccess(string msg) => Handle(msg);
@@ -257,6 +323,36 @@ namespace Yes2SDK
         public void OnDataSetStringError(string msg) => Handle(msg);
         public void OnDataFlushSuccess(string msg) => Handle(msg);
         public void OnDataFlushError(string msg) => Handle(msg);
+
+        // Leaderboard
+        public void OnGetLeaderboardSuccess(string msg) => Handle(msg);
+        public void OnGetLeaderboardError(string msg) => Handle(msg);
+        public void OnSetScoreSuccess(string msg) => Handle(msg);
+        public void OnSetScoreError(string msg) => Handle(msg);
+        public void OnGetEntriesSuccess(string msg) => Handle(msg);
+        public void OnGetEntriesError(string msg) => Handle(msg);
+        public void OnGetPlayerEntrySuccess(string msg) => Handle(msg);
+        public void OnGetPlayerEntryError(string msg) => Handle(msg);
+        public void OnGetConnectedPlayerEntriesSuccess(string msg) => Handle(msg);
+        public void OnGetConnectedPlayerEntriesError(string msg) => Handle(msg);
+
+        // Stats
+        public void OnGetStatsSuccess(string msg) => Handle(msg);
+        public void OnGetStatsError(string msg) => Handle(msg);
+        public void OnSetStatsSuccess(string msg) => Handle(msg);
+        public void OnSetStatsError(string msg) => Handle(msg);
+        public void OnIncrementStatsSuccess(string msg) => Handle(msg);
+        public void OnIncrementStatsError(string msg) => Handle(msg);
+
+        // Config
+        public void OnGetFlagsSuccess(string msg) => Handle(msg);
+        public void OnGetFlagsError(string msg) => Handle(msg);
+
+        // Review
+        public void OnCanReviewSuccess(string msg) => Handle(msg);
+        public void OnCanReviewError(string msg) => Handle(msg);
+        public void OnRequestReviewSuccess(string msg) => Handle(msg);
+        public void OnRequestReviewError(string msg) => Handle(msg);
 
         #endregion
 

--- a/Runtime/Config.meta
+++ b/Runtime/Config.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c1f4a8e2d7b35c69f02e4a1b8d6c3f97

--- a/Runtime/Config/Yes2SDKConfig.cs
+++ b/Runtime/Config/Yes2SDKConfig.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Yes2SDK
+{
+    /// <summary>
+    /// Remote configuration / feature-flag API for Yes2SDK.
+    /// Backed by the platform config API via the Core SDK (window.Yes2SDK.config).
+    /// Flags resolve to a flat string-to-string map delivered to onSuccess as a
+    /// JSON object. Platforms without a remote-config service return the
+    /// caller-provided defaults.
+    /// </summary>
+    public class Yes2SDKConfig
+    {
+        #region Static Callback Fields
+
+        private static Action<string> _getFlagsSuccessCallback;
+        private static Action<Error> _getFlagsErrorCallback;
+
+        #endregion
+
+        #region JavaScript Imports
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Config_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Config_GetFlagsAsyncJS(string optionsJson);
+#endif
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether remote configuration is supported on the current platform.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Config_IsSupportedJS();
+#else
+            Yes2Log.Log("Mock: Config.IsSupported() — returning false");
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Get remote feature flags. onSuccess receives a JSON object of
+        /// name-value string pairs.
+        /// </summary>
+        /// <param name="optionsJson">
+        /// JSON object string of options, e.g.
+        /// {"defaults":{"theme":"dark"},"clientFeatures":[{"name":"vip","value":"1"}]}.
+        /// </param>
+        /// <param name="onSuccess">Called with the flags JSON on success.</param>
+        /// <param name="onError">Called with an error on failure.</param>
+        public void GetFlagsAsync(string optionsJson = "{}", Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getFlagsSuccessCallback = onSuccess;
+            _getFlagsErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Config_GetFlagsAsyncJS(optionsJson ?? "{}");
+#else
+            Yes2Log.Log($"Mock: Config.GetFlagsAsync('{optionsJson}') — returning empty flags");
+            InvokeGetFlagsSuccess("{}");
+#endif
+        }
+
+        #endregion
+
+        #region Internal Callback Invocations (called by Bridge)
+
+        internal static void InvokeGetFlagsSuccess(string flagsJson)
+        {
+            _getFlagsSuccessCallback?.Invoke(flagsJson);
+            _getFlagsSuccessCallback = null;
+            _getFlagsErrorCallback = null;
+        }
+
+        internal static void InvokeGetFlagsError(Error error)
+        {
+            _getFlagsErrorCallback?.Invoke(error);
+            _getFlagsSuccessCallback = null;
+            _getFlagsErrorCallback = null;
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Config/Yes2SDKConfig.cs.meta
+++ b/Runtime/Config/Yes2SDKConfig.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b9d2f6a3c8e145f7a02c5b1d9e4f8a36

--- a/Runtime/Game/Yes2SDKGame.cs
+++ b/Runtime/Game/Yes2SDKGame.cs
@@ -19,6 +19,8 @@ namespace Yes2SDK
 
         private static Action<string> _inviteLinkSuccessCallback;
         private static Action<Error> _inviteLinkErrorCallback;
+        private static Action<long> _serverTimeSuccessCallback;
+        private static Action<Error> _serverTimeErrorCallback;
 
         #endregion
 
@@ -60,6 +62,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern void Yes2SDK_Game_CopyToClipboardJS(string text);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Game_GetServerTimeAsyncJS();
 #endif
 
         #endregion
@@ -196,6 +201,29 @@ namespace Yes2SDK
 #endif
         }
 
+        /// <summary>
+        /// Get the platform server time as Unix epoch milliseconds. onSuccess
+        /// receives the timestamp. Falls back to local time where the platform
+        /// has no server-time API.
+        /// </summary>
+        public void GetServerTimeAsync(Action<long> onSuccess = null, Action<Error> onError = null)
+        {
+            _serverTimeSuccessCallback = onSuccess;
+            _serverTimeErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Game_GetServerTimeAsyncJS();
+#else
+            Yes2Log.Log("Mock: Game.GetServerTimeAsync() — returning local time");
+            InvokeGetServerTimeSuccess(DateTimeOffset.UtcNow.ToUnixTimeMilliseconds().ToString());
+#endif
+        }
+
+        public Task<long> GetServerTimeAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<long>(
+                (success, error) => GetServerTimeAsync(success, error),
+                cancellationToken);
+
         #endregion
 
         #region Internal Callback Invocations (called by Bridge)
@@ -212,6 +240,35 @@ namespace Yes2SDK
             _inviteLinkErrorCallback?.Invoke(error);
             _inviteLinkSuccessCallback = null;
             _inviteLinkErrorCallback = null;
+        }
+
+        internal static void InvokeGetServerTimeSuccess(string timestamp)
+        {
+            if (_serverTimeSuccessCallback != null)
+            {
+                if (long.TryParse(timestamp, out var ms))
+                {
+                    _serverTimeSuccessCallback.Invoke(ms);
+                }
+                else
+                {
+                    _serverTimeErrorCallback?.Invoke(new Error
+                    {
+                        Code = "Unknown",
+                        Message = $"Failed to parse server time: {timestamp}",
+                        Context = "Yes2SDK.Game.GetServerTimeAsync"
+                    });
+                }
+            }
+            _serverTimeSuccessCallback = null;
+            _serverTimeErrorCallback = null;
+        }
+
+        internal static void InvokeGetServerTimeError(Error error)
+        {
+            _serverTimeErrorCallback?.Invoke(error);
+            _serverTimeSuccessCallback = null;
+            _serverTimeErrorCallback = null;
         }
 
         internal static void InvokeSettingsChanged(string settingsJson)

--- a/Runtime/Leaderboard/Yes2SDKLeaderboard.cs
+++ b/Runtime/Leaderboard/Yes2SDKLeaderboard.cs
@@ -1,26 +1,252 @@
 using System;
+using System.Runtime.InteropServices;
 
 namespace Yes2SDK
 {
     /// <summary>
     /// Leaderboard API for Yes2SDK.
-    /// Currently a stub — returns FeatureNotSupported on all platforms.
+    /// Backed by the platform leaderboard API via the Core SDK
+    /// (window.Yes2SDK.leaderboard). Result payloads are delivered to onSuccess
+    /// as JSON strings. Platforms without leaderboards report FeatureNotSupported.
     /// </summary>
-    public class Yes2SDKLeaderboard : Yes2SDKStubModule
+    public class Yes2SDKLeaderboard
     {
-        protected override string FeatureName => "Leaderboards";
-        protected override string ModuleName => "Leaderboard";
+        #region Static Callback Fields
 
+        private static Action<string> _getLeaderboardSuccessCallback;
+        private static Action<Error> _getLeaderboardErrorCallback;
+        private static Action<string> _setScoreSuccessCallback;
+        private static Action<Error> _setScoreErrorCallback;
+        private static Action<string> _getEntriesSuccessCallback;
+        private static Action<Error> _getEntriesErrorCallback;
+        private static Action<string> _getPlayerEntrySuccessCallback;
+        private static Action<Error> _getPlayerEntryErrorCallback;
+        private static Action<string> _getConnectedEntriesSuccessCallback;
+        private static Action<Error> _getConnectedEntriesErrorCallback;
+
+        #endregion
+
+        #region JavaScript Imports
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Leaderboard_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Leaderboard_GetLeaderboardAsyncJS(string name);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Leaderboard_SetScoreAsyncJS(string name, int score, string metadata);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Leaderboard_GetEntriesAsyncJS(string name, int count, int offset);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Leaderboard_GetPlayerEntryAsyncJS(string name);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Leaderboard_GetConnectedPlayerEntriesAsyncJS(string name, int count, int offset);
+#endif
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether leaderboards are supported on the current platform.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Leaderboard_IsSupportedJS();
+#else
+            Yes2Log.Log("Mock: Leaderboard.IsSupported() — returning false");
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Get a leaderboard by name. onSuccess receives the leaderboard as a
+        /// JSON object { name, contextId, entries }.
+        /// </summary>
         public void GetLeaderboardAsync(string leaderboardId, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetLeaderboardAsync), leaderboardId);
+        {
+            _getLeaderboardSuccessCallback = onSuccess;
+            _getLeaderboardErrorCallback = onError;
 
-        public void SetScoreAsync(string leaderboardId, int score, Action onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(SetScoreAsync), $"{leaderboardId}, {score}");
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Leaderboard_GetLeaderboardAsyncJS(leaderboardId);
+#else
+            Yes2Log.Log($"Mock: Leaderboard.GetLeaderboardAsync('{leaderboardId}') — FeatureNotSupported");
+            InvokeGetLeaderboardError(FeatureNotSupportedError("Yes2SDK.Leaderboard.GetLeaderboardAsync"));
+#endif
+        }
 
+        /// <summary>
+        /// Submit a score to a leaderboard. onSuccess receives the player's
+        /// entry as a JSON object.
+        /// </summary>
+        /// <param name="leaderboardId">Leaderboard name/identifier.</param>
+        /// <param name="score">Score to submit.</param>
+        /// <param name="onSuccess">Called with the entry JSON on success.</param>
+        /// <param name="onError">Called with an error on failure.</param>
+        /// <param name="metadata">Optional metadata to attach to the entry.</param>
+        public void SetScoreAsync(
+            string leaderboardId,
+            int score,
+            Action<string> onSuccess = null,
+            Action<Error> onError = null,
+            string metadata = null)
+        {
+            _setScoreSuccessCallback = onSuccess;
+            _setScoreErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Leaderboard_SetScoreAsyncJS(leaderboardId, score, metadata ?? string.Empty);
+#else
+            Yes2Log.Log($"Mock: Leaderboard.SetScoreAsync('{leaderboardId}', {score}) — FeatureNotSupported");
+            InvokeSetScoreError(FeatureNotSupportedError("Yes2SDK.Leaderboard.SetScoreAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Get leaderboard entries. onSuccess receives a JSON array of entries.
+        /// </summary>
         public void GetEntriesAsync(string leaderboardId, int count, int offset, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetEntriesAsync), $"{leaderboardId}, {count}, {offset}");
+        {
+            _getEntriesSuccessCallback = onSuccess;
+            _getEntriesErrorCallback = onError;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Leaderboard_GetEntriesAsyncJS(leaderboardId, count, offset);
+#else
+            Yes2Log.Log($"Mock: Leaderboard.GetEntriesAsync('{leaderboardId}', {count}, {offset}) — FeatureNotSupported");
+            InvokeGetEntriesError(FeatureNotSupportedError("Yes2SDK.Leaderboard.GetEntriesAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Get the current player's entry. onSuccess receives the entry as a
+        /// JSON object, or the literal "null" if the player is not ranked.
+        /// </summary>
         public void GetPlayerEntryAsync(string leaderboardId, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetPlayerEntryAsync), leaderboardId);
+        {
+            _getPlayerEntrySuccessCallback = onSuccess;
+            _getPlayerEntryErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Leaderboard_GetPlayerEntryAsyncJS(leaderboardId);
+#else
+            Yes2Log.Log($"Mock: Leaderboard.GetPlayerEntryAsync('{leaderboardId}') — FeatureNotSupported");
+            InvokeGetPlayerEntryError(FeatureNotSupportedError("Yes2SDK.Leaderboard.GetPlayerEntryAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Get entries for connected players (friends). onSuccess receives a JSON
+        /// array of entries. Not supported on every platform (e.g. Yandex).
+        /// </summary>
+        public void GetConnectedPlayerEntriesAsync(string leaderboardId, int count, int offset, Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getConnectedEntriesSuccessCallback = onSuccess;
+            _getConnectedEntriesErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Leaderboard_GetConnectedPlayerEntriesAsyncJS(leaderboardId, count, offset);
+#else
+            Yes2Log.Log($"Mock: Leaderboard.GetConnectedPlayerEntriesAsync('{leaderboardId}', {count}, {offset}) — FeatureNotSupported");
+            InvokeGetConnectedPlayerEntriesError(FeatureNotSupportedError("Yes2SDK.Leaderboard.GetConnectedPlayerEntriesAsync"));
+#endif
+        }
+
+        #endregion
+
+        #region Internal Callback Invocations (called by Bridge)
+
+        internal static void InvokeGetLeaderboardSuccess(string leaderboardJson)
+        {
+            _getLeaderboardSuccessCallback?.Invoke(leaderboardJson);
+            _getLeaderboardSuccessCallback = null;
+            _getLeaderboardErrorCallback = null;
+        }
+
+        internal static void InvokeGetLeaderboardError(Error error)
+        {
+            _getLeaderboardErrorCallback?.Invoke(error);
+            _getLeaderboardSuccessCallback = null;
+            _getLeaderboardErrorCallback = null;
+        }
+
+        internal static void InvokeSetScoreSuccess(string entryJson)
+        {
+            _setScoreSuccessCallback?.Invoke(entryJson);
+            _setScoreSuccessCallback = null;
+            _setScoreErrorCallback = null;
+        }
+
+        internal static void InvokeSetScoreError(Error error)
+        {
+            _setScoreErrorCallback?.Invoke(error);
+            _setScoreSuccessCallback = null;
+            _setScoreErrorCallback = null;
+        }
+
+        internal static void InvokeGetEntriesSuccess(string entriesJson)
+        {
+            _getEntriesSuccessCallback?.Invoke(entriesJson);
+            _getEntriesSuccessCallback = null;
+            _getEntriesErrorCallback = null;
+        }
+
+        internal static void InvokeGetEntriesError(Error error)
+        {
+            _getEntriesErrorCallback?.Invoke(error);
+            _getEntriesSuccessCallback = null;
+            _getEntriesErrorCallback = null;
+        }
+
+        internal static void InvokeGetPlayerEntrySuccess(string entryJson)
+        {
+            _getPlayerEntrySuccessCallback?.Invoke(entryJson);
+            _getPlayerEntrySuccessCallback = null;
+            _getPlayerEntryErrorCallback = null;
+        }
+
+        internal static void InvokeGetPlayerEntryError(Error error)
+        {
+            _getPlayerEntryErrorCallback?.Invoke(error);
+            _getPlayerEntrySuccessCallback = null;
+            _getPlayerEntryErrorCallback = null;
+        }
+
+        internal static void InvokeGetConnectedPlayerEntriesSuccess(string entriesJson)
+        {
+            _getConnectedEntriesSuccessCallback?.Invoke(entriesJson);
+            _getConnectedEntriesSuccessCallback = null;
+            _getConnectedEntriesErrorCallback = null;
+        }
+
+        internal static void InvokeGetConnectedPlayerEntriesError(Error error)
+        {
+            _getConnectedEntriesErrorCallback?.Invoke(error);
+            _getConnectedEntriesSuccessCallback = null;
+            _getConnectedEntriesErrorCallback = null;
+        }
+
+        #endregion
+
+        #region Private Helpers
+
+        private static Error FeatureNotSupportedError(string context)
+        {
+            return new Error
+            {
+                Code = "FeatureNotSupported",
+                Message = "This feature is not supported on the current platform",
+                Context = context
+            };
+        }
+
+        #endregion
     }
 }

--- a/Runtime/Player/Yes2SDKPlayer.cs
+++ b/Runtime/Player/Yes2SDKPlayer.cs
@@ -32,6 +32,16 @@ namespace Yes2SDK
         private static Action<Error> _getConnectedPlayersErrorCallback;
         private static Action<string> _getSignedPlayerInfoSuccessCallback;
         private static Action<Error> _getSignedPlayerInfoErrorCallback;
+        private static Action<string> _getUniqueIdSuccessCallback;
+        private static Action<Error> _getUniqueIdErrorCallback;
+        private static Action<string> _getIDsPerGameSuccessCallback;
+        private static Action<Error> _getIDsPerGameErrorCallback;
+        private static Action<string> _getPayingStatusSuccessCallback;
+        private static Action<Error> _getPayingStatusErrorCallback;
+        private static Action<string> _getModeSuccessCallback;
+        private static Action<Error> _getModeErrorCallback;
+        private static Action<string> _getPhotoSuccessCallback;
+        private static Action<Error> _getPhotoErrorCallback;
 
         #endregion
 
@@ -61,6 +71,21 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern int Yes2SDK_IsConnectedPlayersSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Player_GetUniqueIdAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Player_GetIDsPerGameAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Player_GetPayingStatusAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Player_GetModeAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Player_GetPhotoAsyncJS(string size);
 #endif
 
         #endregion
@@ -199,6 +224,92 @@ namespace Yes2SDK
 #endif
         }
 
+        /// <summary>
+        /// Get a stable unique identifier for the current player.
+        /// onSuccess receives the id string.
+        /// </summary>
+        public void GetUniqueIdAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getUniqueIdSuccessCallback = onSuccess;
+            _getUniqueIdErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Player_GetUniqueIdAsyncJS();
+#else
+            Yes2Log.Log("Mock: GetUniqueIdAsync() — returning \"anonymous\"");
+            InvokeGetUniqueIdSuccess("anonymous");
+#endif
+        }
+
+        /// <summary>
+        /// Get the player's cross-game identities. onSuccess receives a JSON array
+        /// of { appId, userId } objects.
+        /// </summary>
+        public void GetIDsPerGameAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getIDsPerGameSuccessCallback = onSuccess;
+            _getIDsPerGameErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Player_GetIDsPerGameAsyncJS();
+#else
+            Yes2Log.Log("Mock: GetIDsPerGameAsync() — returning empty list");
+            InvokeGetIDsPerGameSuccess("[]");
+#endif
+        }
+
+        /// <summary>
+        /// Get the player's paying status: "paying", "partially_paying",
+        /// "not_paying", or "unknown". onSuccess receives the status string.
+        /// </summary>
+        public void GetPayingStatusAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getPayingStatusSuccessCallback = onSuccess;
+            _getPayingStatusErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Player_GetPayingStatusAsyncJS();
+#else
+            Yes2Log.Log("Mock: GetPayingStatusAsync() — returning \"unknown\"");
+            InvokeGetPayingStatusSuccess("unknown");
+#endif
+        }
+
+        /// <summary>
+        /// Get the player's session mode: "lite", "authorized", or "unknown".
+        /// onSuccess receives the mode string.
+        /// </summary>
+        public void GetModeAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getModeSuccessCallback = onSuccess;
+            _getModeErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Player_GetModeAsyncJS();
+#else
+            Yes2Log.Log("Mock: GetModeAsync() — returning \"unknown\"");
+            InvokeGetModeSuccess("unknown");
+#endif
+        }
+
+        /// <summary>
+        /// Get the player's avatar URL for the requested size. onSuccess receives
+        /// the URL string, or the literal "null" if no photo is available.
+        /// </summary>
+        /// <param name="size">Requested photo size (platform-defined, e.g. "medium").</param>
+        public void GetPhotoAsync(string size, Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _getPhotoSuccessCallback = onSuccess;
+            _getPhotoErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Player_GetPhotoAsyncJS(size ?? string.Empty);
+#else
+            Yes2Log.Log($"Mock: GetPhotoAsync('{size}') — returning null");
+            InvokeGetPhotoSuccess("null");
+#endif
+        }
+
         // Task-returning overloads.
 
         public Task<PlayerInfo> GetPlayerAsync(CancellationToken cancellationToken)
@@ -229,6 +340,31 @@ namespace Yes2SDK
         public Task<string> GetSignedPlayerInfoAsync(string payload, CancellationToken cancellationToken)
             => TaskCallbackHelper.ToTask<string>(
                 (success, error) => GetSignedPlayerInfoAsync(payload, success, error),
+                cancellationToken);
+
+        public Task<string> GetUniqueIdAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetUniqueIdAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetIDsPerGameAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetIDsPerGameAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetPayingStatusAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetPayingStatusAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetModeAsync(CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetModeAsync(success, error),
+                cancellationToken);
+
+        public Task<string> GetPhotoAsync(string size, CancellationToken cancellationToken)
+            => TaskCallbackHelper.ToTask<string>(
+                (success, error) => GetPhotoAsync(size, success, error),
                 cancellationToken);
 
         /// <summary>
@@ -362,6 +498,76 @@ namespace Yes2SDK
             _getSignedPlayerInfoErrorCallback?.Invoke(error);
             _getSignedPlayerInfoSuccessCallback = null;
             _getSignedPlayerInfoErrorCallback = null;
+        }
+
+        internal static void InvokeGetUniqueIdSuccess(string id)
+        {
+            _getUniqueIdSuccessCallback?.Invoke(id);
+            _getUniqueIdSuccessCallback = null;
+            _getUniqueIdErrorCallback = null;
+        }
+
+        internal static void InvokeGetUniqueIdError(Error error)
+        {
+            _getUniqueIdErrorCallback?.Invoke(error);
+            _getUniqueIdSuccessCallback = null;
+            _getUniqueIdErrorCallback = null;
+        }
+
+        internal static void InvokeGetIDsPerGameSuccess(string identitiesJson)
+        {
+            _getIDsPerGameSuccessCallback?.Invoke(identitiesJson);
+            _getIDsPerGameSuccessCallback = null;
+            _getIDsPerGameErrorCallback = null;
+        }
+
+        internal static void InvokeGetIDsPerGameError(Error error)
+        {
+            _getIDsPerGameErrorCallback?.Invoke(error);
+            _getIDsPerGameSuccessCallback = null;
+            _getIDsPerGameErrorCallback = null;
+        }
+
+        internal static void InvokeGetPayingStatusSuccess(string status)
+        {
+            _getPayingStatusSuccessCallback?.Invoke(status);
+            _getPayingStatusSuccessCallback = null;
+            _getPayingStatusErrorCallback = null;
+        }
+
+        internal static void InvokeGetPayingStatusError(Error error)
+        {
+            _getPayingStatusErrorCallback?.Invoke(error);
+            _getPayingStatusSuccessCallback = null;
+            _getPayingStatusErrorCallback = null;
+        }
+
+        internal static void InvokeGetModeSuccess(string mode)
+        {
+            _getModeSuccessCallback?.Invoke(mode);
+            _getModeSuccessCallback = null;
+            _getModeErrorCallback = null;
+        }
+
+        internal static void InvokeGetModeError(Error error)
+        {
+            _getModeErrorCallback?.Invoke(error);
+            _getModeSuccessCallback = null;
+            _getModeErrorCallback = null;
+        }
+
+        internal static void InvokeGetPhotoSuccess(string photoUrl)
+        {
+            _getPhotoSuccessCallback?.Invoke(photoUrl);
+            _getPhotoSuccessCallback = null;
+            _getPhotoErrorCallback = null;
+        }
+
+        internal static void InvokeGetPhotoError(Error error)
+        {
+            _getPhotoErrorCallback?.Invoke(error);
+            _getPhotoSuccessCallback = null;
+            _getPhotoErrorCallback = null;
         }
 
         #endregion

--- a/Runtime/Review.meta
+++ b/Runtime/Review.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f6c3b9d1a4e82f57c01b3d8e6a2f4c19

--- a/Runtime/Review/Yes2SDKReview.cs
+++ b/Runtime/Review/Yes2SDKReview.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Yes2SDK
+{
+    /// <summary>
+    /// Game rating / feedback-prompt API for Yes2SDK.
+    /// Backed by the platform review API via the Core SDK (window.Yes2SDK.review).
+    /// The prompt is gated behind an eligibility check. Result payloads are
+    /// delivered to onSuccess as JSON strings. Platforms without a rating service
+    /// report ineligibility and a no-op feedback result.
+    /// </summary>
+    public class Yes2SDKReview
+    {
+        #region Static Callback Fields
+
+        private static Action<string> _canReviewSuccessCallback;
+        private static Action<Error> _canReviewErrorCallback;
+        private static Action<string> _requestReviewSuccessCallback;
+        private static Action<Error> _requestReviewErrorCallback;
+
+        #endregion
+
+        #region JavaScript Imports
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Review_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Review_CanReviewAsyncJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Review_RequestReviewAsyncJS();
+#endif
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether the rating prompt is supported on the current platform.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Review_IsSupportedJS();
+#else
+            Yes2Log.Log("Mock: Review.IsSupported() — returning false");
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Check whether the player can currently be shown the rating prompt.
+        /// onSuccess receives a JSON object { canReview, reason? }.
+        /// </summary>
+        public void CanReviewAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _canReviewSuccessCallback = onSuccess;
+            _canReviewErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Review_CanReviewAsyncJS();
+#else
+            Yes2Log.Log("Mock: Review.CanReviewAsync() — returning canReview=false");
+            InvokeCanReviewSuccess("{\"canReview\":false}");
+#endif
+        }
+
+        /// <summary>
+        /// Request the in-game rating / feedback prompt. onSuccess receives a JSON
+        /// object { feedbackSent }.
+        /// </summary>
+        public void RequestReviewAsync(Action<string> onSuccess = null, Action<Error> onError = null)
+        {
+            _requestReviewSuccessCallback = onSuccess;
+            _requestReviewErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Review_RequestReviewAsyncJS();
+#else
+            Yes2Log.Log("Mock: Review.RequestReviewAsync() — returning feedbackSent=false");
+            InvokeRequestReviewSuccess("{\"feedbackSent\":false}");
+#endif
+        }
+
+        #endregion
+
+        #region Internal Callback Invocations (called by Bridge)
+
+        internal static void InvokeCanReviewSuccess(string eligibilityJson)
+        {
+            _canReviewSuccessCallback?.Invoke(eligibilityJson);
+            _canReviewSuccessCallback = null;
+            _canReviewErrorCallback = null;
+        }
+
+        internal static void InvokeCanReviewError(Error error)
+        {
+            _canReviewErrorCallback?.Invoke(error);
+            _canReviewSuccessCallback = null;
+            _canReviewErrorCallback = null;
+        }
+
+        internal static void InvokeRequestReviewSuccess(string resultJson)
+        {
+            _requestReviewSuccessCallback?.Invoke(resultJson);
+            _requestReviewSuccessCallback = null;
+            _requestReviewErrorCallback = null;
+        }
+
+        internal static void InvokeRequestReviewError(Error error)
+        {
+            _requestReviewErrorCallback?.Invoke(error);
+            _requestReviewSuccessCallback = null;
+            _requestReviewErrorCallback = null;
+        }
+
+        #endregion
+    }
+}

--- a/Runtime/Review/Yes2SDKReview.cs.meta
+++ b/Runtime/Review/Yes2SDKReview.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d7a4e1b8f2c63a95e08b4d2f7c1a5e93

--- a/Runtime/Session/Yes2SDKSession.cs
+++ b/Runtime/Session/Yes2SDKSession.cs
@@ -46,6 +46,9 @@ namespace Yes2SDK
 
         [DllImport("__Internal")]
         private static extern int Yes2SDK_IsAudioEnabledJS();
+
+        [DllImport("__Internal")]
+        private static extern string Yes2SDK_GetDeviceInfoJS();
 #endif
 
         #endregion
@@ -188,6 +191,20 @@ namespace Yes2SDK
 #else
             Yes2Log.Log("Mock: IsAudioEnabled() — returning true");
             return true;
+#endif
+        }
+
+        /// <summary>
+        /// Get detailed device information synchronously as a JSON string of
+        /// shape { type, isMobile, isDesktop, isTablet, isTV }.
+        /// </summary>
+        public string GetDeviceInfo()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_GetDeviceInfoJS();
+#else
+            Yes2Log.Log("Mock: GetDeviceInfo() — returning desktop");
+            return "{\"type\":\"desktop\",\"isMobile\":false,\"isDesktop\":true,\"isTablet\":false,\"isTV\":false}";
 #endif
         }
 

--- a/Runtime/Stats/Yes2SDKStats.cs
+++ b/Runtime/Stats/Yes2SDKStats.cs
@@ -1,23 +1,175 @@
 using System;
+using System.Runtime.InteropServices;
+using Newtonsoft.Json;
 
 namespace Yes2SDK
 {
     /// <summary>
     /// Stats API for Yes2SDK.
-    /// Currently a stub — returns FeatureNotSupported on all platforms.
+    /// Backed by the platform stats API via the Core SDK (window.Yes2SDK.stats).
+    /// Stats are name-value pairs (numbers). Maps cross the C#/JS boundary as
+    /// JSON strings; results are delivered to onSuccess as JSON objects.
+    /// Platforms without stats report FeatureNotSupported.
     /// </summary>
-    public class Yes2SDKStats : Yes2SDKStubModule
+    public class Yes2SDKStats
     {
-        protected override string FeatureName => "Stats";
-        protected override string ModuleName => "Stats";
+        #region Static Callback Fields
 
+        private static Action<string> _getStatsSuccessCallback;
+        private static Action<Error> _getStatsErrorCallback;
+        private static Action _setStatsSuccessCallback;
+        private static Action<Error> _setStatsErrorCallback;
+        private static Action<string> _incrementStatsSuccessCallback;
+        private static Action<Error> _incrementStatsErrorCallback;
+
+        #endregion
+
+        #region JavaScript Imports
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+        [DllImport("__Internal")]
+        private static extern bool Yes2SDK_Stats_IsSupportedJS();
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Stats_GetStatsAsyncJS(string keysJson);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Stats_SetStatsAsyncJS(string statsJson);
+
+        [DllImport("__Internal")]
+        private static extern void Yes2SDK_Stats_IncrementStatsAsyncJS(string incrementsJson);
+#endif
+
+        #endregion
+
+        #region Public API
+
+        /// <summary>
+        /// Whether stats are supported on the current platform.
+        /// </summary>
+        public bool IsSupported()
+        {
+#if UNITY_WEBGL && !UNITY_EDITOR
+            return Yes2SDK_Stats_IsSupportedJS();
+#else
+            Yes2Log.Log("Mock: Stats.IsSupported() — returning false");
+            return false;
+#endif
+        }
+
+        /// <summary>
+        /// Get stats by key. onSuccess receives a JSON object of name-value pairs.
+        /// </summary>
+        /// <param name="keys">Stat keys to retrieve.</param>
+        /// <param name="onSuccess">Called with the stats JSON on success.</param>
+        /// <param name="onError">Called with an error on failure.</param>
         public void GetStatsAsync(string[] keys, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(GetStatsAsync));
+        {
+            _getStatsSuccessCallback = onSuccess;
+            _getStatsErrorCallback = onError;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Stats_GetStatsAsyncJS(JsonConvert.SerializeObject(keys ?? Array.Empty<string>()));
+#else
+            Yes2Log.Log("Mock: Stats.GetStatsAsync() — FeatureNotSupported");
+            InvokeGetStatsError(FeatureNotSupportedError("Yes2SDK.Stats.GetStatsAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Set stats. Pass a JSON object string of name-value pairs, e.g.
+        /// {"kills":42,"level":7}.
+        /// </summary>
         public void SetStatsAsync(string statsJson, Action onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(SetStatsAsync));
+        {
+            _setStatsSuccessCallback = onSuccess;
+            _setStatsErrorCallback = onError;
 
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Stats_SetStatsAsyncJS(statsJson ?? "{}");
+#else
+            Yes2Log.Log($"Mock: Stats.SetStatsAsync('{statsJson}') — FeatureNotSupported");
+            InvokeSetStatsError(FeatureNotSupportedError("Yes2SDK.Stats.SetStatsAsync"));
+#endif
+        }
+
+        /// <summary>
+        /// Increment stats. Pass a JSON object string of name-delta pairs, e.g.
+        /// {"kills":1}. onSuccess receives the updated stats as a JSON object.
+        /// </summary>
         public void IncrementStatsAsync(string incrementsJson, Action<string> onSuccess = null, Action<Error> onError = null)
-            => Stub(onError, nameof(IncrementStatsAsync));
+        {
+            _incrementStatsSuccessCallback = onSuccess;
+            _incrementStatsErrorCallback = onError;
+
+#if UNITY_WEBGL && !UNITY_EDITOR
+            Yes2SDK_Stats_IncrementStatsAsyncJS(incrementsJson ?? "{}");
+#else
+            Yes2Log.Log($"Mock: Stats.IncrementStatsAsync('{incrementsJson}') — FeatureNotSupported");
+            InvokeIncrementStatsError(FeatureNotSupportedError("Yes2SDK.Stats.IncrementStatsAsync"));
+#endif
+        }
+
+        #endregion
+
+        #region Internal Callback Invocations (called by Bridge)
+
+        internal static void InvokeGetStatsSuccess(string statsJson)
+        {
+            _getStatsSuccessCallback?.Invoke(statsJson);
+            _getStatsSuccessCallback = null;
+            _getStatsErrorCallback = null;
+        }
+
+        internal static void InvokeGetStatsError(Error error)
+        {
+            _getStatsErrorCallback?.Invoke(error);
+            _getStatsSuccessCallback = null;
+            _getStatsErrorCallback = null;
+        }
+
+        internal static void InvokeSetStatsSuccess()
+        {
+            _setStatsSuccessCallback?.Invoke();
+            _setStatsSuccessCallback = null;
+            _setStatsErrorCallback = null;
+        }
+
+        internal static void InvokeSetStatsError(Error error)
+        {
+            _setStatsErrorCallback?.Invoke(error);
+            _setStatsSuccessCallback = null;
+            _setStatsErrorCallback = null;
+        }
+
+        internal static void InvokeIncrementStatsSuccess(string statsJson)
+        {
+            _incrementStatsSuccessCallback?.Invoke(statsJson);
+            _incrementStatsSuccessCallback = null;
+            _incrementStatsErrorCallback = null;
+        }
+
+        internal static void InvokeIncrementStatsError(Error error)
+        {
+            _incrementStatsErrorCallback?.Invoke(error);
+            _incrementStatsSuccessCallback = null;
+            _incrementStatsErrorCallback = null;
+        }
+
+        #endregion
+
+        #region Private Helpers
+
+        private static Error FeatureNotSupportedError(string context)
+        {
+            return new Error
+            {
+                Code = "FeatureNotSupported",
+                Message = "This feature is not supported on the current platform",
+                Context = context
+            };
+        }
+
+        #endregion
     }
 }

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -78,7 +78,7 @@ namespace Yes2SDK
         /// <summary>
         /// SDK version string.
         /// </summary>
-        public static string Version => "2.4.5";
+        public static string Version => "2.5.0";
 
         private static Yes2SDKAds _ads;
 
@@ -139,7 +139,8 @@ namespace Yes2SDK
         private static Yes2SDKLeaderboard _leaderboard;
 
         /// <summary>
-        /// Leaderboard API. Stub — returns FeatureNotSupported on Poki.
+        /// Leaderboard API for scores, entries, and player ranking. Backed by the
+        /// platform leaderboard API where available; reports FeatureNotSupported otherwise.
         /// </summary>
         public static Yes2SDKLeaderboard Leaderboard
         {
@@ -223,7 +224,8 @@ namespace Yes2SDK
         private static Yes2SDKStats _stats;
 
         /// <summary>
-        /// Stats API. Stub — returns FeatureNotSupported on Poki.
+        /// Stats API for name-value counters. Backed by the platform stats API
+        /// where available; reports FeatureNotSupported otherwise.
         /// </summary>
         public static Yes2SDKStats Stats
         {
@@ -315,6 +317,36 @@ namespace Yes2SDK
             {
                 _score ??= new Yes2SDKScore();
                 return _score;
+            }
+        }
+
+        private static Yes2SDKConfig _config;
+
+        /// <summary>
+        /// Config API for remote feature flags. Backed by the platform config API
+        /// where available; returns caller-provided defaults otherwise.
+        /// </summary>
+        public static Yes2SDKConfig Config
+        {
+            get
+            {
+                _config ??= new Yes2SDKConfig();
+                return _config;
+            }
+        }
+
+        private static Yes2SDKReview _review;
+
+        /// <summary>
+        /// Review API for the in-game rating / feedback prompt. Backed by the
+        /// platform review API where available; reports ineligibility otherwise.
+        /// </summary>
+        public static Yes2SDKReview Review
+        {
+            get
+            {
+                _review ??= new Yes2SDKReview();
+                return _review;
             }
         }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.4.5",
+    "version": "2.5.0",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
Adds Yandex-supported modules and player APIs to the Unity SDK (v2.5.0).

### Added
- **`Yes2SDK.Leaderboard`** and **`Yes2SDK.Stats`** — now functional (were stubs).
- **`Yes2SDK.Config`** — remote feature flags (`GetFlagsAsync`, with defaults fallback).
- **`Yes2SDK.Review`** — in-game rating prompt (`CanReviewAsync` / `RequestReviewAsync`).
- **`Yes2SDK.Player`** — `GetUniqueIdAsync`, `GetIDsPerGameAsync`, `GetPayingStatusAsync`, `GetModeAsync`, `GetPhotoAsync(size)`.
- **`Yes2SDK.Banners.GetBannerStatusAsync()`**, **`Yes2SDK.Game.GetServerTimeAsync()`**, **`Yes2SDK.Session.GetDeviceInfo()`**.

### Changed
- `Leaderboard.SetScoreAsync` success callback now returns the resulting entry as JSON (was parameterless).

New WebGL jslibs + Bridge routing for all new callbacks. Capabilities are reported per-platform via `IsSupported()`.

> Not yet validated in a WebGL build on-device — needs an Editor compile + Yandex smoke test before tagging the release.
