### PR TITLE
fix crazygames wrapper module parity with C# bridge layer

### DIFF
--- a/.github/workflows/wrapper-parity.yml
+++ b/.github/workflows/wrapper-parity.yml
@@ -1,0 +1,14 @@
+name: wrapper-parity
+on:
+  push:
+  pull_request:
+jobs:
+  parity:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Check wrapper module parity
+        run: node scripts/check-wrapper-parity.mjs

--- a/Plugins/Yes2SDKPlatformInit.jslib
+++ b/Plugins/Yes2SDKPlatformInit.jslib
@@ -53,6 +53,12 @@ mergeInto(LibraryManager.library, {
         // ===================================================================
         // CrazyGames wrapper — mirrors Yes2SDK-CrazyGames/index.html exactly
         // ===================================================================
+        // Core's CrazyGames strategies reject unsupported features with this exact shape
+        // (code matches yes2sdk-core FEATURE_NOT_SUPPORTED). Keep in sync with Core semantics.
+        function __y2fns(feature) {
+            return { code: 'FEATURE_NOT_SUPPORTED', message: feature + ' is not supported on the current platform.' };
+        }
+
         window.Yes2SDK = {
             _initialized: false,
             _platform: 'crazygames',
@@ -678,6 +684,46 @@ mergeInto(LibraryManager.library, {
                         window.__y2.log('SubmitScore:', encryptedScore);
                     }
                 }
+            },
+
+            // Leaderboard module - unsupported on CrazyGames (mirrors Core crazygames-leaderboard-strategy)
+            leaderboard: {
+                getLeaderboardAsync: function(name) { return Promise.reject(__y2fns('Leaderboard.getLeaderboardAsync')); },
+                setScoreAsync: function(name, score, metadata) { return Promise.reject(__y2fns('Leaderboard.setScoreAsync')); },
+                getEntriesAsync: function(name, count, offset) { return Promise.reject(__y2fns('Leaderboard.getEntriesAsync')); },
+                getPlayerEntryAsync: function(name) { return Promise.reject(__y2fns('Leaderboard.getPlayerEntryAsync')); },
+                getConnectedPlayerEntriesAsync: function(name, count, offset) { return Promise.reject(__y2fns('Leaderboard.getConnectedPlayerEntriesAsync')); },
+                isSupported: function() { return false; }
+            },
+
+            // Stats module - unsupported on CrazyGames (mirrors Core crazygames-stats-strategy)
+            stats: {
+                getStatsAsync: function(keys) { return Promise.reject(__y2fns('Stats.getStatsAsync')); },
+                setStatsAsync: function(stats) { return Promise.reject(__y2fns('Stats.setStatsAsync')); },
+                incrementStatsAsync: function(increments) { return Promise.reject(__y2fns('Stats.incrementStatsAsync')); },
+                isSupported: function() { return false; }
+            },
+
+            // Config module - graceful degradation: resolve provided defaults (mirrors Core crazygames-config-strategy)
+            config: {
+                getFlagsAsync: function(options) { return Promise.resolve((options && options.defaults) || {}); },
+                isSupported: function() { return false; }
+            },
+
+            // Review module - graceful degradation: resolve unsupported result (mirrors Core crazygames-review-strategy)
+            review: {
+                canReviewAsync: function() { return Promise.resolve({ canReview: false, reason: 'FEATURE_NOT_SUPPORTED' }); },
+                requestReviewAsync: function() { return Promise.resolve({ feedbackSent: false }); },
+                isSupported: function() { return false; }
+            },
+
+            // IAP module - unsupported on CrazyGames (mirrors Core crazygames-iap-strategy; IAP only functions on Yandex)
+            iap: {
+                getCatalogAsync: function() { return Promise.reject(__y2fns('IAP.getCatalogAsync')); },
+                purchaseAsync: function(config) { return Promise.reject(__y2fns('IAP.purchaseAsync')); },
+                getPurchasesAsync: function() { return Promise.reject(__y2fns('IAP.getPurchasesAsync')); },
+                consumePurchaseAsync: function(purchaseToken) { return Promise.reject(__y2fns('IAP.consumePurchaseAsync')); },
+                isSupported: function() { return false; }
             }
         };
 

--- a/scripts/check-wrapper-parity.mjs
+++ b/scripts/check-wrapper-parity.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// Verifies the CrazyGames wrapper (Yes2SDKPlatformInit.jslib) defines every module that a
+// C#->JS bridge calls into. Source of truth = the bridge files' window.Yes2SDK.<module> refs,
+// so the required surface cannot drift from the actual C# call sites.
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+const pluginsDir = join(root, 'Plugins');
+const WRAPPER = 'Yes2SDKPlatformInit.jslib';
+
+const bridges = readdirSync(pluginsDir).filter((f) => f.endsWith('.jslib') && f !== WRAPPER);
+
+// Capture two-level accesses: window.Yes2SDK.<module>.<method>(  — module must start lowercase
+// (excludes internals like ._sdk and one-level calls like .on() / .initializeAsync()).
+const moduleRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\.([a-zA-Z0-9]+)\s*\(/g;
+const required = new Map(); // module -> Set(methods)
+for (const f of bridges) {
+  const src = readFileSync(join(pluginsDir, f), 'utf8');
+  let m;
+  while ((m = moduleRe.exec(src)) !== null) {
+    const [, mod, method] = m;
+    if (!required.has(mod)) required.set(mod, new Set());
+    required.get(mod).add(method);
+  }
+}
+
+const wrapperSrc = readFileSync(join(pluginsDir, WRAPPER), 'utf8');
+const hasModule = (mod) => new RegExp('(^|[^\\w.])' + mod + '\\s*:\\s*\\{', 'm').test(wrapperSrc);
+const hasMethod = (method) => new RegExp('(^|[^\\w.])' + method + '\\s*:\\s*function', 'm').test(wrapperSrc);
+
+const missingModules = [];
+const missingMethods = [];
+for (const [mod, methods] of required) {
+  if (!hasModule(mod)) { missingModules.push(mod); continue; }
+  for (const method of methods) {
+    if (!hasMethod(method)) missingMethods.push(mod + '.' + method);
+  }
+}
+
+if (missingModules.length) {
+  console.error('FAIL: ' + WRAPPER + ' is missing modules referenced by bridges:');
+  for (const mod of missingModules.sort()) console.error('  - ' + mod);
+}
+if (missingMethods.length) {
+  console.warn('WARN (heuristic, non-gating): wrapper may be missing methods:');
+  for (const mm of missingMethods.sort()) console.warn('  - ' + mm);
+}
+if (!missingModules.length && !missingMethods.length) {
+  console.log('OK: wrapper defines all ' + required.size + ' bridge-referenced modules.');
+} else if (!missingModules.length) {
+  console.log('OK (modules): all ' + required.size + ' bridge modules present; see method warnings.');
+}
+
+process.exit(missingModules.length ? 1 : 0);

--- a/scripts/check-wrapper-parity.mjs
+++ b/scripts/check-wrapper-parity.mjs
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
-// Verifies the CrazyGames wrapper (Yes2SDKPlatformInit.jslib) defines every module that a
+// Verifies the CrazyGames wrapper (Yes2SDKPlatformInit.jslib) defines every MODULE that a
 // C#->JS bridge calls into. Source of truth = the bridge files' window.Yes2SDK.<module> refs,
-// so the required surface cannot drift from the actual C# call sites.
+// so the required module surface cannot drift from the actual C# call sites.
+//
+// SCOPE: module presence only. This check does NOT verify method-level parity — a wrapper
+// module can be present yet omit individual methods the bridges call, which on CrazyGames
+// surfaces as an uncaught TypeError (undefined deref) for un-try/caught raw calls. Method-level
+// parity is tracked separately in yes2sdk-unity#73. A reliable method check needs a real JS
+// parser (regex/brace-walking false-positives on getters, shorthand, and string literals), so
+// it is intentionally left out here rather than shipped as a misleading non-gating warning.
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
@@ -12,74 +19,30 @@ const WRAPPER = 'Yes2SDKPlatformInit.jslib';
 
 const bridges = readdirSync(pluginsDir).filter((f) => f.endsWith('.jslib') && f !== WRAPPER);
 
-// Capture two-level accesses: window.Yes2SDK.<module>.<method>(  — module must start lowercase
+// Capture module accesses: window.Yes2SDK.<module>.  — module must start lowercase
 // (excludes internals like ._sdk and one-level calls like .on() / .initializeAsync()).
-const moduleRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\.([a-zA-Z0-9]+)\s*\(/g;
-const required = new Map(); // module -> Set(methods)
+const moduleRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\./g;
+const required = new Set();
 for (const f of bridges) {
   const src = readFileSync(join(pluginsDir, f), 'utf8');
-  // Fix #3: reset lastIndex before each file scan so no stale state leaks between inputs.
   moduleRe.lastIndex = 0;
   let m;
-  while ((m = moduleRe.exec(src)) !== null) {
-    const [, mod, method] = m;
-    if (!required.has(mod)) required.set(mod, new Set());
-    required.get(mod).add(method);
-  }
+  while ((m = moduleRe.exec(src)) !== null) required.add(m[1]);
 }
 
 const wrapperSrc = readFileSync(join(pluginsDir, WRAPPER), 'utf8');
 
-// Fix #1: append (?!\w) so "ad" does not prefix-match "ads:" — the module name must end at a
+// Append (?!\w) so "ad" does not prefix-match "ads:" — the module name must end at a
 // non-word boundary before the key separator.
 const hasModule = (mod) =>
   new RegExp('(^|[^\\w.])' + mod + '(?!\\w)\\s*:\\s*\\{', 'm').test(wrapperSrc);
 
-// Fix #2: scope the method search to the specific module's object-literal body so a method
-// present in a *different* module does not satisfy the check for this one.
-// Extract the module block by counting braces from the opening '{' of "<mod>: {".
-const extractModuleBlock = (mod) => {
-  // Use the same word-boundary pattern as hasModule to find the block start.
-  const keyRe = new RegExp('(?:^|[^\\w.])' + mod + '(?!\\w)\\s*:\\s*\\{', 'm');
-  const keyMatch = keyRe.exec(wrapperSrc);
-  if (!keyMatch) return '';
-  // Walk forward counting braces; the opening '{' is the last char of the match.
-  const openPos = keyMatch.index + keyMatch[0].length - 1;
-  let depth = 0;
-  let end = openPos;
-  for (let i = openPos; i < wrapperSrc.length; i++) {
-    if (wrapperSrc[i] === '{') depth++;
-    else if (wrapperSrc[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
-  }
-  return wrapperSrc.slice(openPos, end + 1);
-};
-const hasMethod = (mod, method) => {
-  const block = extractModuleBlock(mod);
-  if (!block) return false;
-  return new RegExp('(^|[^\\w.])' + method + '\\s*:\\s*function', 'm').test(block);
-};
-
-const missingModules = [];
-const missingMethods = [];
-for (const [mod, methods] of required) {
-  if (!hasModule(mod)) { missingModules.push(mod); continue; }
-  for (const method of methods) {
-    if (!hasMethod(mod, method)) missingMethods.push(mod + '.' + method);
-  }
-}
+const missingModules = [...required].filter((mod) => !hasModule(mod)).sort();
 
 if (missingModules.length) {
   console.error('FAIL: ' + WRAPPER + ' is missing modules referenced by bridges:');
-  for (const mod of missingModules.sort()) console.error('  - ' + mod);
-}
-if (missingMethods.length) {
-  console.warn('WARN (heuristic, non-gating): wrapper may be missing methods:');
-  for (const mm of missingMethods.sort()) console.warn('  - ' + mm);
-}
-if (!missingModules.length && !missingMethods.length) {
-  console.log('OK: wrapper defines all ' + required.size + ' bridge-referenced modules.');
-} else if (!missingModules.length) {
-  console.log('OK (modules): all ' + required.size + ' bridge modules present; see method warnings.');
+  for (const mod of missingModules) console.error('  - ' + mod);
+  process.exit(1);
 }
 
-process.exit(missingModules.length ? 1 : 0);
+console.log('OK: wrapper defines all ' + required.size + ' bridge-referenced modules.');

--- a/scripts/check-wrapper-parity.mjs
+++ b/scripts/check-wrapper-parity.mjs
@@ -18,6 +18,8 @@ const moduleRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\.([a-zA-Z0-9]+)\s*\(/g;
 const required = new Map(); // module -> Set(methods)
 for (const f of bridges) {
   const src = readFileSync(join(pluginsDir, f), 'utf8');
+  // Fix #3: reset lastIndex before each file scan so no stale state leaks between inputs.
+  moduleRe.lastIndex = 0;
   let m;
   while ((m = moduleRe.exec(src)) !== null) {
     const [, mod, method] = m;
@@ -27,15 +29,42 @@ for (const f of bridges) {
 }
 
 const wrapperSrc = readFileSync(join(pluginsDir, WRAPPER), 'utf8');
-const hasModule = (mod) => new RegExp('(^|[^\\w.])' + mod + '\\s*:\\s*\\{', 'm').test(wrapperSrc);
-const hasMethod = (method) => new RegExp('(^|[^\\w.])' + method + '\\s*:\\s*function', 'm').test(wrapperSrc);
+
+// Fix #1: append (?!\w) so "ad" does not prefix-match "ads:" — the module name must end at a
+// non-word boundary before the key separator.
+const hasModule = (mod) =>
+  new RegExp('(^|[^\\w.])' + mod + '(?!\\w)\\s*:\\s*\\{', 'm').test(wrapperSrc);
+
+// Fix #2: scope the method search to the specific module's object-literal body so a method
+// present in a *different* module does not satisfy the check for this one.
+// Extract the module block by counting braces from the opening '{' of "<mod>: {".
+const extractModuleBlock = (mod) => {
+  // Use the same word-boundary pattern as hasModule to find the block start.
+  const keyRe = new RegExp('(?:^|[^\\w.])' + mod + '(?!\\w)\\s*:\\s*\\{', 'm');
+  const keyMatch = keyRe.exec(wrapperSrc);
+  if (!keyMatch) return '';
+  // Walk forward counting braces; the opening '{' is the last char of the match.
+  const openPos = keyMatch.index + keyMatch[0].length - 1;
+  let depth = 0;
+  let end = openPos;
+  for (let i = openPos; i < wrapperSrc.length; i++) {
+    if (wrapperSrc[i] === '{') depth++;
+    else if (wrapperSrc[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+  }
+  return wrapperSrc.slice(openPos, end + 1);
+};
+const hasMethod = (mod, method) => {
+  const block = extractModuleBlock(mod);
+  if (!block) return false;
+  return new RegExp('(^|[^\\w.])' + method + '\\s*:\\s*function', 'm').test(block);
+};
 
 const missingModules = [];
 const missingMethods = [];
 for (const [mod, methods] of required) {
   if (!hasModule(mod)) { missingModules.push(mod); continue; }
   for (const method of methods) {
-    if (!hasMethod(method)) missingMethods.push(mod + '.' + method);
+    if (!hasMethod(mod, method)) missingMethods.push(mod + '.' + method);
   }
 }
 


### PR DESCRIPTION
## Summary

- Mirror 5 modules (`leaderboard`, `stats`, `config`, `review`, `iap`) into the CrazyGames `window.Yes2SDK` wrapper (`Plugins/Yes2SDKPlatformInit.jslib`) with Core-matching CrazyGames semantics: leaderboard/stats/iap reject `FEATURE_NOT_SUPPORTED`, config resolves caller defaults, review resolves ineligible/no-op, all `isSupported()` return false.
- Add `scripts/check-wrapper-parity.mjs` — a zero-dependency Node check that fails when a bridge references a module the wrapper does not define.
- Add `.github/workflows/wrapper-parity.yml` to run that check on push/PR (the repo's first CI beyond release notification).

Before this change, those modules had C#→jslib bridges but no wrapper implementation, so on CrazyGames they returned a misleading `NotInitialized` error instead of `FEATURE_NOT_SUPPORTED`, and config/review failed instead of degrading gracefully. No crash (the bridges guard with `__y2h.has`), so this is behavioral divergence, not the TypeError originally reported.

Fixes #67

## Test plan

- `node scripts/check-wrapper-parity.mjs` → exit 0, "all 15 bridge modules present".
- Negative: delete a module key → exit 1 naming the missing module.
- Whole-branch review confirmed brace integrity (literal balanced, closes `};`), method-name fidelity against all 5 bridge call sites (no `undefined` deref), and semantics matching Core's `crazygames-*-strategy.ts`.
