### PR TITLE
guard all sync isSupported probes against missing method on active global

### DIFF
--- a/Plugins/Yes2SDKAuth.jslib
+++ b/Plugins/Yes2SDKAuth.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_Auth_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_Auth_IsSupportedJS: function() {
-        return __y2h.has('auth') && window.Yes2SDK.auth.isSupported() ? 1 : 0;
+        if (!__y2h.has('auth')) return false;
+        try { return window.Yes2SDK.auth.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_Auth_GetCurrentUserAsyncJS__deps: ['$__y2h'],

--- a/Plugins/Yes2SDKConfig.jslib
+++ b/Plugins/Yes2SDKConfig.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_Config_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_Config_IsSupportedJS: function() {
-        return __y2h.has('config') && window.Yes2SDK.config.isSupported() ? 1 : 0;
+        if (!__y2h.has('config')) return false;
+        try { return window.Yes2SDK.config.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_Config_GetFlagsAsyncJS__deps: ['$__y2h'],

--- a/Plugins/Yes2SDKIAP.jslib
+++ b/Plugins/Yes2SDKIAP.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_IAP_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IAP_IsSupportedJS: function() {
-        return __y2h.has('iap') && window.Yes2SDK.iap.isSupported() ? 1 : 0;
+        if (!__y2h.has('iap')) return false;
+        try { return window.Yes2SDK.iap.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_IAP_GetCatalogAsyncJS__deps: ['$__y2h'],

--- a/Plugins/Yes2SDKLeaderboard.jslib
+++ b/Plugins/Yes2SDKLeaderboard.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_Leaderboard_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_Leaderboard_IsSupportedJS: function() {
-        return __y2h.has('leaderboard') && window.Yes2SDK.leaderboard.isSupported() ? 1 : 0;
+        if (!__y2h.has('leaderboard')) return false;
+        try { return window.Yes2SDK.leaderboard.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_Leaderboard_GetLeaderboardAsyncJS__deps: ['$__y2h'],

--- a/Plugins/Yes2SDKPlayer.jslib
+++ b/Plugins/Yes2SDKPlayer.jslib
@@ -99,13 +99,13 @@ mergeInto(LibraryManager.library, {
     // Whether player data persistence is supported on the current platform
     Yes2SDK_IsDataSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IsDataSupportedJS: function() {
-        return (__y2h.has('player') && window.Yes2SDK.player.isDataSupported()) ? 1 : 0;
+        return (__y2h.has('player') && typeof window.Yes2SDK.player.isDataSupported === 'function' && window.Yes2SDK.player.isDataSupported()) ? 1 : 0;
     },
 
     // Whether connected players are supported on the current platform
     Yes2SDK_IsConnectedPlayersSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IsConnectedPlayersSupportedJS: function() {
-        return (__y2h.has('player') && window.Yes2SDK.player.isConnectedPlayersSupported()) ? 1 : 0;
+        return (__y2h.has('player') && typeof window.Yes2SDK.player.isConnectedPlayersSupported === 'function' && window.Yes2SDK.player.isConnectedPlayersSupported()) ? 1 : 0;
     },
 
     // Get a stable unique player id

--- a/Plugins/Yes2SDKPlayer.jslib
+++ b/Plugins/Yes2SDKPlayer.jslib
@@ -99,13 +99,17 @@ mergeInto(LibraryManager.library, {
     // Whether player data persistence is supported on the current platform
     Yes2SDK_IsDataSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IsDataSupportedJS: function() {
-        return (__y2h.has('player') && typeof window.Yes2SDK.player.isDataSupported === 'function' && window.Yes2SDK.player.isDataSupported()) ? 1 : 0;
+        if (!__y2h.has('player')) return false;
+        try { return window.Yes2SDK.player.isDataSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     // Whether connected players are supported on the current platform
     Yes2SDK_IsConnectedPlayersSupportedJS__deps: ['$__y2h'],
     Yes2SDK_IsConnectedPlayersSupportedJS: function() {
-        return (__y2h.has('player') && typeof window.Yes2SDK.player.isConnectedPlayersSupported === 'function' && window.Yes2SDK.player.isConnectedPlayersSupported()) ? 1 : 0;
+        if (!__y2h.has('player')) return false;
+        try { return window.Yes2SDK.player.isConnectedPlayersSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     // Get a stable unique player id

--- a/Plugins/Yes2SDKReview.jslib
+++ b/Plugins/Yes2SDKReview.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_Review_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_Review_IsSupportedJS: function() {
-        return __y2h.has('review') && window.Yes2SDK.review.isSupported() ? 1 : 0;
+        if (!__y2h.has('review')) return false;
+        try { return window.Yes2SDK.review.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_Review_CanReviewAsyncJS__deps: ['$__y2h'],

--- a/Plugins/Yes2SDKStats.jslib
+++ b/Plugins/Yes2SDKStats.jslib
@@ -2,7 +2,9 @@ mergeInto(LibraryManager.library, {
 
     Yes2SDK_Stats_IsSupportedJS__deps: ['$__y2h'],
     Yes2SDK_Stats_IsSupportedJS: function() {
-        return __y2h.has('stats') && window.Yes2SDK.stats.isSupported() ? 1 : 0;
+        if (!__y2h.has('stats')) return false;
+        try { return window.Yes2SDK.stats.isSupported() ? 1 : 0; }
+        catch (e) { return 0; }
     },
 
     Yes2SDK_Stats_GetStatsAsyncJS__deps: ['$__y2h'],


### PR DESCRIPTION
## Summary

Harden every **synchronous `isSupported` capability probe** in the jslib bridges against a missing method on the active `window.Yes2SDK` global. Each probe guarded only with `__y2h.has('<module>')` (module present) and then called `window.Yes2SDK.<module>.isSupported()` directly — a `TypeError` if the active global exposes the module but not that method.

Converted all 8 sync probes to the repo's existing `has() + try/catch` idiom (already used by `banners`/`score`/`friends`), which returns `0` instead of throwing and additionally covers an `isSupported` that exists but throws internally:

- `Yes2SDKPlayer.jslib` — `IsDataSupported`, `IsConnectedPlayersSupported` (the original #66 sites)
- `Yes2SDKAuth.jslib`, `Yes2SDKConfig.jslib`, `Yes2SDKIAP.jslib`, `Yes2SDKLeaderboard.jslib`, `Yes2SDKReview.jslib`, `Yes2SDKStats.jslib` — same unguarded raw-deref pattern, surfaced during PR review.

Fixes #66

## Test plan

- No jslib test infra in this repo. Verified by inspection: all 8 probe sites now short-circuit on a missing module (`return false`) and swallow a missing/throwing method (`catch -> return 0`), matching the established `banners`/`score`/`friends` idiom.
- Async raw-call method gaps (player getUniqueId etc., data/banners/game) are a separate failure mode tracked in #73; out of scope here.
