### PR TITLE
scope wrapper-parity push trigger to main

### DIFF
--- a/.github/workflows/wrapper-parity.yml
+++ b/.github/workflows/wrapper-parity.yml
@@ -1,6 +1,7 @@
 name: wrapper-parity
 on:
   push:
+    branches: [main]
   pull_request:
 jobs:
   parity:


### PR DESCRIPTION
@
## Summary
- `wrapper-parity.yml` triggered on bare `push:` + `pull_request:`, so every PR push ran the job twice and it fired on every branch push.
- Scope `push` to `main`; PRs still gated via `pull_request`, direct `main` pushes still checked.

## Test plan
- Open a PR: `wrapper-parity` check appears once, not twice.
- Push a non-default branch without a PR: no `wrapper-parity` run.

Follows PR #72 (introduced the workflow); flagged in that review, deferred as out of scope.
@