### PR TITLE
mirror missing crazygames wrapper methods and gate method-level parity

### DIFF
--- a/.github/workflows/wrapper-parity.yml
+++ b/.github/workflows/wrapper-parity.yml
@@ -11,5 +11,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
-      - name: Check wrapper module parity
+      - name: Check wrapper method parity
         run: node scripts/check-wrapper-parity.mjs

--- a/Plugins/Yes2SDKPlatformInit.jslib
+++ b/Plugins/Yes2SDKPlatformInit.jslib
@@ -205,6 +205,13 @@ mergeInto(LibraryManager.library, {
 
                 isAdBlocked: function() {
                     return false;
+                },
+
+                // Best-effort readiness — CG has no explicit signal; ad module present => may be available
+                // (mirrors Core crazygames-ads-strategy.isRewardedAdAvailable).
+                isRewardedAdAvailable: function() {
+                    var sdk = window.Yes2SDK._sdk;
+                    return !!(sdk && sdk.ad);
                 }
             },
 
@@ -318,6 +325,25 @@ mergeInto(LibraryManager.library, {
                         }
                     } catch(e) {}
                     return Promise.resolve(source);
+                },
+
+                // CrazyGames has no native audio-enabled signal; assume enabled
+                // (mirrors Core crazygames-session-strategy.isAudioEnabled).
+                isAudioEnabled: function() {
+                    return true;
+                },
+
+                // Detailed device info. CrazyGames has no TV class, so isTV is always false
+                // (mirrors Core crazygames-session-strategy.getDeviceInfo shape).
+                getDeviceInfo: function() {
+                    var type = this.getDevice();
+                    return {
+                        type: type,
+                        isMobile: type === 'mobile',
+                        isDesktop: type === 'desktop',
+                        isTablet: type === 'tablet',
+                        isTV: false
+                    };
                 }
             },
 
@@ -395,6 +421,53 @@ mergeInto(LibraryManager.library, {
                         message: 'Signed player info is not supported on CrazyGames',
                         context: 'player.getSignedPlayerInfoAsync'
                     });
+                },
+
+                // Stable unique id — CrazyGames uses the username (or 'anonymous').
+                // Mirrors Core crazygames-player-strategy.getUniqueId (= getPlayer().id).
+                getUniqueId: function() {
+                    return this.getPlayerAsync().then(function(player) {
+                        return player.id;
+                    });
+                },
+
+                // CrazyGames has no cross-game identity API (Core returns []).
+                getIDsPerGame: function() {
+                    return Promise.resolve([]);
+                },
+
+                // CrazyGames does not expose a paying status (Core returns 'unknown').
+                getPayingStatus: function() {
+                    return Promise.resolve('unknown');
+                },
+
+                // Logged-in users are 'authorized', guests 'lite' (Core: getUser()).
+                getMode: function() {
+                    var sdk = window.Yes2SDK._sdk;
+                    if (!sdk || !sdk.user) return Promise.resolve('lite');
+                    return sdk.user.getUser().then(function(user) {
+                        return user ? 'authorized' : 'lite';
+                    }).catch(function() {
+                        return 'unknown';
+                    });
+                },
+
+                // CrazyGames exposes one profile picture URL, no size variants
+                // (Core crazygames-player-strategy.getPhoto = getPlayer().photo).
+                getPhoto: function(size) {
+                    return this.getPlayerAsync().then(function(player) {
+                        return player.photo;
+                    });
+                },
+
+                // CrazyGames syncs player data for logged-in users (Core: isDataSupported = true).
+                isDataSupported: function() {
+                    return true;
+                },
+
+                // Connected players are not a CrazyGames feature (Core: isConnectedPlayersSupported = false).
+                isConnectedPlayersSupported: function() {
+                    return false;
                 }
             },
 
@@ -462,6 +535,27 @@ mergeInto(LibraryManager.library, {
                 deleteAll: function() {
                     var sdk = window.Yes2SDK._sdk;
                     if (sdk && sdk.data) sdk.data.clear();
+                },
+
+                // Durable string write. CG data.setItem is synchronous; resolve true on
+                // success, false on throw (mirrors Core crazygames-data-strategy.setItemAsync).
+                setStringAsync: function(key, value) {
+                    var sdk = window.Yes2SDK._sdk;
+                    if (!sdk || !sdk.data) return Promise.resolve(false);
+                    try {
+                        var result = sdk.data.setItem(key, value);
+                        if (result && typeof result.then === 'function') {
+                            return result.then(function() { return true; }).catch(function() { return false; });
+                        }
+                        return Promise.resolve(true);
+                    } catch(e) {
+                        return Promise.resolve(false);
+                    }
+                },
+
+                // CrazyGames auto-flushes (debounced); no explicit flush needed.
+                flushAsync: function() {
+                    return Promise.resolve(true);
                 }
             },
 
@@ -599,6 +693,12 @@ mergeInto(LibraryManager.library, {
                     if (sdk && sdk.game && sdk.game.copyToClipboard) {
                         sdk.game.copyToClipboard(text);
                     }
+                },
+
+                // CrazyGames has no server-time API; fall back to local clock
+                // (mirrors Core crazygames-game-strategy.getServerTimeAsync).
+                getServerTimeAsync: function() {
+                    return Promise.resolve(Date.now());
                 }
             },
 
@@ -634,6 +734,17 @@ mergeInto(LibraryManager.library, {
                 refreshBanners: function() {
                     var sdk = window.Yes2SDK._sdk;
                     if (sdk && sdk.banner && sdk.banner.refreshBanners) sdk.banner.refreshBanners();
+                },
+
+                // CrazyGames has no banner status query — banners are fire-and-forget
+                // (mirrors Core crazygames-banners-strategy.getBannerStatusAsync).
+                getBannerStatusAsync: function() {
+                    return Promise.resolve({ isShowing: false, reason: 'STATUS_QUERY_NOT_SUPPORTED' });
+                },
+
+                // Banners work on CrazyGames (Core crazygames-banners-strategy.isSupported = true).
+                isSupported: function() {
+                    return true;
                 }
             },
 
@@ -662,6 +773,11 @@ mergeInto(LibraryManager.library, {
                             total: (friends || []).length
                         };
                     });
+                },
+
+                // Friends work on CrazyGames (Core crazygames-friends-strategy.isSupported = true).
+                isSupported: function() {
+                    return true;
                 }
             },
 
@@ -683,6 +799,11 @@ mergeInto(LibraryManager.library, {
                     } else {
                         window.__y2.log('SubmitScore:', encryptedScore);
                     }
+                },
+
+                // Score submission works on CrazyGames (Core crazygames-score-strategy.isSupported = true).
+                isSupported: function() {
+                    return true;
                 }
             },
 

--- a/scripts/check-wrapper-parity.mjs
+++ b/scripts/check-wrapper-parity.mjs
@@ -1,17 +1,22 @@
 #!/usr/bin/env node
-// Verifies the CrazyGames wrapper (Yes2SDKPlatformInit.jslib) defines every MODULE that a
-// C#->JS bridge calls into. Source of truth = the bridge files' window.Yes2SDK.<module> refs,
-// so the required module surface cannot drift from the actual C# call sites.
+// Verifies the CrazyGames wrapper (Yes2SDKPlatformInit.jslib) defines every module AND every
+// method that a C#->JS bridge calls into. Source of truth = the bridge files' window.Yes2SDK.*
+// references, so the required surface cannot drift from the actual C# call sites.
 //
-// SCOPE: module presence only. This check does NOT verify method-level parity — a wrapper
-// module can be present yet omit individual methods the bridges call, which on CrazyGames
-// surfaces as an uncaught TypeError (undefined deref) for un-try/caught raw calls. Method-level
-// parity is tracked separately in yes2sdk-unity#73. A reliable method check needs a real JS
-// parser (regex/brace-walking false-positives on getters, shorthand, and string literals), so
-// it is intentionally left out here rather than shipped as a misleading non-gating warning.
+// Why method-level matters: each bridge guards only with __y2h.has('<module>') (module present
+// -> true), then dereferences the method directly. A wrapper module that is present but omits a
+// method surfaces on CrazyGames as an uncaught TypeError (undefined deref) for the raw-call async
+// bridges whose trailing .then().catch() runs after the throw. Tracked in yes2sdk-unity#73.
+//
+// How the wrapper is inspected: rather than regex/brace-walking the source (which false-positives
+// on getters, shorthand, and string literals), we evaluate the .jslib in a vm sandbox with a
+// stubbed CrazyGames global, run the postset init function, and introspect the resulting
+// window.Yes2SDK object. This reports exact method presence with no parsing heuristics and no
+// added dependency (node:vm is stdlib).
 import { readFileSync, readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
+import vm from 'node:vm';
 
 const root = join(dirname(fileURLToPath(import.meta.url)), '..');
 const pluginsDir = join(root, 'Plugins');
@@ -19,30 +24,74 @@ const WRAPPER = 'Yes2SDKPlatformInit.jslib';
 
 const bridges = readdirSync(pluginsDir).filter((f) => f.endsWith('.jslib') && f !== WRAPPER);
 
-// Capture module accesses: window.Yes2SDK.<module>.  — module must start lowercase
-// (excludes internals like ._sdk and one-level calls like .on() / .initializeAsync()).
-const moduleRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\./g;
-const required = new Set();
+// Capture module.method accesses: window.Yes2SDK.<module>.<member>
+// - module must start lowercase (excludes internals like ._sdk)
+// - skip _-prefixed members (private fields the bridges never call)
+const memberRe = /window\.Yes2SDK\.([a-z][a-zA-Z0-9]*)\.([a-zA-Z_$][a-zA-Z0-9_$]*)/g;
+const required = new Map(); // module -> Set<method>
 for (const f of bridges) {
   const src = readFileSync(join(pluginsDir, f), 'utf8');
-  moduleRe.lastIndex = 0;
+  memberRe.lastIndex = 0;
   let m;
-  while ((m = moduleRe.exec(src)) !== null) required.add(m[1]);
+  while ((m = memberRe.exec(src)) !== null) {
+    const [, mod, member] = m;
+    if (member.startsWith('_')) continue;
+    if (!required.has(mod)) required.set(mod, new Set());
+    required.get(mod).add(member);
+  }
 }
 
+// Build the wrapper's window.Yes2SDK object in a sandbox.
 const wrapperSrc = readFileSync(join(pluginsDir, WRAPPER), 'utf8');
+const library = {};
+const sandbox = {
+  window: { CrazyGames: { SDK: {} } },
+  navigator: { userAgent: '', language: 'en' },
+  document: { referrer: '' },
+  // Silence the wrapper's __y2.log/warn chatter; surface only errors.
+  console: { log() {}, warn() {}, error: console.error.bind(console) },
+  mergeInto: (_lib, additions) => Object.assign(library, additions),
+  LibraryManager: { library: {} },
+};
+vm.createContext(sandbox);
+vm.runInContext(wrapperSrc, sandbox, { filename: WRAPPER });
 
-// Append (?!\w) so "ad" does not prefix-match "ads:" — the module name must end at a
-// non-word boundary before the key separator.
-const hasModule = (mod) =>
-  new RegExp('(^|[^\\w.])' + mod + '(?!\\w)\\s*:\\s*\\{', 'm').test(wrapperSrc);
-
-const missingModules = [...required].filter((mod) => !hasModule(mod)).sort();
-
-if (missingModules.length) {
-  console.error('FAIL: ' + WRAPPER + ' is missing modules referenced by bridges:');
-  for (const mod of missingModules) console.error('  - ' + mod);
+if (typeof library.$__yes2PlatformInit !== 'function') {
+  console.error('FAIL: ' + WRAPPER + ' did not register $__yes2PlatformInit via mergeInto.');
+  process.exit(1);
+}
+library.$__yes2PlatformInit();
+const api = sandbox.window.Yes2SDK;
+if (!api) {
+  console.error('FAIL: ' + WRAPPER + ' init did not create window.Yes2SDK (CG guard not met?).');
   process.exit(1);
 }
 
-console.log('OK: wrapper defines all ' + required.size + ' bridge-referenced modules.');
+const missing = []; // { module, method? }
+let methodCount = 0;
+for (const [mod, methods] of [...required].sort((a, b) => a[0].localeCompare(b[0]))) {
+  const modObj = api[mod];
+  if (!modObj || typeof modObj !== 'object') {
+    missing.push({ module: mod });
+    continue;
+  }
+  for (const method of [...methods].sort()) {
+    methodCount++;
+    if (typeof modObj[method] !== 'function') {
+      missing.push({ module: mod, method });
+    }
+  }
+}
+
+if (missing.length) {
+  console.error('FAIL: ' + WRAPPER + ' is missing surface referenced by bridges:');
+  for (const x of missing) {
+    console.error(x.method ? `  - ${x.module}.${x.method}` : `  - ${x.module} (entire module)`);
+  }
+  process.exit(1);
+}
+
+console.log(
+  'OK: wrapper defines all ' + methodCount + ' bridge-referenced methods across ' +
+  required.size + ' modules.'
+);


### PR DESCRIPTION
## Summary
- Add the methods the C#→jslib bridges call but the CrazyGames fallback wrapper (`Yes2SDKPlatformInit.jslib`) omitted, each mirroring the matching Core `crazygames-*-strategy.ts` semantics. Fixes uncaught synchronous `TypeError` on raw-call async bridges (player/data/banners/game) and capability misreports on the try/caught probes (score/banners/friends `isSupported`, `ads.isRewardedAdAvailable`, session `getDeviceInfo`/`isAudioEnabled`) when running on CrazyGames outside the dashboard-injected Core runtime.
- Rewrite `scripts/check-wrapper-parity.mjs` from a module-presence regex to a method-level gate that introspects the wrapper via `node:vm` (stdlib, no new dep) — exact method presence, no false positives on getters/shorthand/string literals.

Fixes #73

## Test plan
- `node scripts/check-wrapper-parity.mjs` → `OK: wrapper defines all 93 bridge-referenced methods across 15 modules.` (exit 0).
- RED verified: removing any covered method makes the gate exit 1 and list the missing `module.method`.
- `wrapper-parity` CI runs the gate on push + PR.