### PR TITLE
Warn at init when injected Core is older than the build requires

### DIFF
--- a/Plugins/Yes2SDK.jslib
+++ b/Plugins/Yes2SDK.jslib
@@ -56,6 +56,45 @@ mergeInto(LibraryManager.library, {
     Yes2SDK_InitializeJS: function() {
         window.__y2.log('[Init] Step 1: Yes2SDK_InitializeJS called');
 
+        // Minimum injected Core runtime this wrapper build is compatible with.
+        // Distinct from the wrapper's own version (Yes2SDK.Version) — see Yes2SDK.cs.
+        // Must match the dashboard's MIN_CORE_BY_ENGINE floor for Unity.
+        var REQUIRED_CORE_VERSION = '2.2.0';
+
+        // Compare two semver strings on major.minor.patch (pre-release/build metadata ignored).
+        // Returns 1 if a > b, -1 if a < b, 0 if equal.
+        function compareSemver(a, b) {
+            var pa = String(a).split('.');
+            var pb = String(b).split('.');
+            for (var i = 0; i < 3; i++) {
+                var na = parseInt(pa[i], 10) || 0;
+                var nb = parseInt(pb[i], 10) || 0;
+                if (na > nb) return 1;
+                if (na < nb) return -1;
+            }
+            return 0;
+        }
+
+        // Warn (non-blocking) if the injected Core is older than this build requires.
+        // Reads Core's OWN version field, which is Core-only: the CrazyGames wrapper
+        // exposes a second window.Yes2SDK with no .version, and pre-2.2.0 Core has no
+        // getter either — both read as null, which means "can't verify", NOT a skew.
+        function checkCoreVersion() {
+            try {
+                var coreVer = (window.Yes2SDK && typeof window.Yes2SDK.version === 'string')
+                    ? window.Yes2SDK.version : null;
+                if (coreVer === null) return; // CG wrapper or pre-2.2.0 Core — cannot verify, skip
+                if (compareSemver(coreVer, REQUIRED_CORE_VERSION) < 0) {
+                    window.__y2.warn('Injected Core v' + coreVer + ' is older than this build requires (v' +
+                        REQUIRED_CORE_VERSION + '). Some SDK calls may silently no-op. ' +
+                        'Update the injected Core runtime.');
+                }
+            } catch (error) {
+                // A version probe must never break init.
+                window.__y2.warn('[Init] Core version check skipped:', error);
+            }
+        }
+
         // Helper: subscribe to platform lifecycle events ONCE after init succeeds.
         // Required for YouTube Playables certification (integration #14, #21, #22).
         // The Core SDK fires these events; we forward them to Unity via SendMessage.
@@ -83,6 +122,9 @@ mergeInto(LibraryManager.library, {
 
         // Helper: run init once wrapper exists (try-catch prevents uncaught throws → no popup)
         function doInit() {
+            // window.Yes2SDK is guaranteed defined here (paths A/B/C confirm the wrapper
+            // before calling doInit), so this is the single point to verify Core skew.
+            checkCoreVersion();
             try {
                 window.__y2.log('[Init] doInit: calling window.Yes2SDK.initializeAsync()');
                 window.Yes2SDK.initializeAsync()


### PR DESCRIPTION
## Summary
- Compare the injected `window.Yes2SDK.version` against a baked Core floor (`2.2.0`) at init in `Yes2SDK_InitializeJS` -> `doInit()`; log a non-blocking warning when the injected Core is older than this build requires.
- Guards the CrazyGames double-global and pre-2.2.0 Core: a missing `.version` reads as "can't verify", not a skew. The probe is wrapped in try/catch so it can never break init.
- Implements the engine-side half of build-to-Core skew detection the dashboard cannot do statically (the wrapper version is compiled into the WASM blob).

Refs yes2games/yes2dashboard#136 (cross-repo; close that issue manually on merge of this + the Defold PR).

## Test plan
- `node --check` on the jslib passes.
- Logic unit-tested (9/9): older Core -> warn; equal/newer -> silent; `2.10 > 2.2` numeric compare; CrazyGames/null/non-string -> skip.
- Manual (no SDK CI): build a WebGL game, inject Core below floor -> one console warning at init; inject current Core -> none; on CrazyGames -> reads Core's `.version`, no false warning; game still initializes.
