### PR TITLE
feat: Yandex account-selection dialog events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.5.1] - 2026-07-08
 
 ### Added
 - **Account-selection dialog events (Yandex).** `Yes2SDK.OnAccountDialogOpen` and `Yes2SDK.OnAccountDialogClose` fire when the platform's account-selection dialog opens and closes; pause gameplay and audio while it is open.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **Account-selection dialog events (Yandex).** `Yes2SDK.OnAccountDialogOpen` and `Yes2SDK.OnAccountDialogClose` fire when the platform's account-selection dialog opens and closes; pause gameplay and audio while it is open.
+
 ## [2.5.0] - 2026-06-24
 
 ### Added

--- a/Plugins/Yes2SDK.jslib
+++ b/Plugins/Yes2SDK.jslib
@@ -75,7 +75,13 @@ mergeInto(LibraryManager.library, {
                     var enabled = (data && data.enabled) === true;
                     SendMessage('Bridge', 'OnAudioEnabledChange', JSON.stringify({ enabled: enabled }));
                 });
-                window.__y2.log('[Lifecycle] pause/resume/audioEnabledChange wired to Bridge');
+                window.Yes2SDK.on('accountDialogOpen', function() {
+                    SendMessage('Bridge', 'OnAccountDialogOpen', '');
+                });
+                window.Yes2SDK.on('accountDialogClose', function() {
+                    SendMessage('Bridge', 'OnAccountDialogClose', '');
+                });
+                window.__y2.log('[Lifecycle] pause/resume/audioEnabledChange/accountDialogOpen/accountDialogClose wired to Bridge');
             } catch(error) {
                 window.__y2.error('[Lifecycle] failed to wire lifecycle events:', error);
             }

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The current SDK version is also exposed at runtime via `Yes2SDK.Version` (string
 
 1. Open **Window > Package Manager**
 2. Click **+** > **Add package from git URL...**
-3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.5.0`
+3. Enter: `https://github.com/yes2games/yes2sdk-unity.git#v2.5.1`
 4. Click **Add**
 
-> Pinning the URL with `#v2.5.0` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
+> Pinning the URL with `#v2.5.1` keeps the package hash stable across resolves. Bump the tag when a newer release ships. Without a tag, Package Manager re-resolves against `main` on every refresh and reports phantom diffs.
 
 ### Via Local Folder
 

--- a/Runtime/Bridge.cs
+++ b/Runtime/Bridge.cs
@@ -64,6 +64,8 @@ namespace Yes2SDK
             ["OnPause"] = _ => Callbacks.InvokePause(),
             ["OnResume"] = _ => Callbacks.InvokeResume(),
             ["OnAudioEnabledChange"] = data => Callbacks.InvokeAudioEnabledChange(data),
+            ["OnAccountDialogOpen"] = _ => Callbacks.InvokeAccountDialogOpen(),
+            ["OnAccountDialogClose"] = _ => Callbacks.InvokeAccountDialogClose(),
 
             // Ads
             ["OnInterstitialBeforeAd"] = _ => Yes2SDKAds.InvokeInterstitialBeforeAd(),
@@ -238,6 +240,8 @@ namespace Yes2SDK
         public void OnPause(string msg) => Handle(msg);
         public void OnResume(string msg) => Handle(msg);
         public void OnAudioEnabledChange(string msg) => Handle(msg);
+        public void OnAccountDialogOpen(string msg) => Handle(msg);
+        public void OnAccountDialogClose(string msg) => Handle(msg);
 
         // Ads
         public void OnInterstitialBeforeAd(string msg) => Handle(msg);
@@ -431,6 +435,16 @@ namespace Yes2SDK
         internal static void InvokeResume()
         {
             Yes2SDK.InvokeResume();
+        }
+
+        internal static void InvokeAccountDialogOpen()
+        {
+            Yes2SDK.InvokeAccountDialogOpen();
+        }
+
+        internal static void InvokeAccountDialogClose()
+        {
+            Yes2SDK.InvokeAccountDialogClose();
         }
 
         internal static void InvokeAudioEnabledChange(string dataJson)

--- a/Runtime/Yes2SDK.cs
+++ b/Runtime/Yes2SDK.cs
@@ -57,6 +57,19 @@ namespace Yes2SDK
         public static event Action<bool> OnAudioEnabledChange;
 
         /// <summary>
+        /// Called when the platform's account-selection dialog is opened (Yandex only).
+        /// Pause gameplay and audio while the dialog is open, then resume on
+        /// <see cref="OnAccountDialogClose"/>.
+        /// </summary>
+        public static event Action OnAccountDialogOpen;
+
+        /// <summary>
+        /// Called when the platform's account-selection dialog is closed (Yandex only).
+        /// Resume gameplay and audio that were paused on <see cref="OnAccountDialogOpen"/>.
+        /// </summary>
+        public static event Action OnAccountDialogClose;
+
+        /// <summary>
         /// Called when an SDK error occurs.
         /// </summary>
         public static event Action<Error> OnError;
@@ -535,6 +548,24 @@ namespace Yes2SDK
         {
             Yes2Log.Log("Game resumed");
             OnResume?.Invoke();
+        }
+
+        /// <summary>
+        /// Invokes the OnAccountDialogOpen event. Called internally by the bridge.
+        /// </summary>
+        internal static void InvokeAccountDialogOpen()
+        {
+            Yes2Log.Log("Account dialog opened");
+            OnAccountDialogOpen?.Invoke();
+        }
+
+        /// <summary>
+        /// Invokes the OnAccountDialogClose event. Called internally by the bridge.
+        /// </summary>
+        internal static void InvokeAccountDialogClose()
+        {
+            Yes2Log.Log("Account dialog closed");
+            OnAccountDialogClose?.Invoke();
         }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.yes2games.yes2sdk",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "displayName": "Yes2SDK",
     "description": "Yes2SDK Unity package for the SuperSDK pipeline",
     "unity": "2021.3",


### PR DESCRIPTION
Adds Yandex account-selection dialog lifecycle events.

`Yes2SDK.OnAccountDialogOpen` and `Yes2SDK.OnAccountDialogClose` fire when the platform's account-selection dialog opens and closes — pause gameplay and audio while it is open, resume on close. Yandex-only; other platforms never fire them.

Subscribe after `InitializeAsync` succeeds:

```csharp
Yes2SDK.OnAccountDialogOpen  += () => PauseGame();
Yes2SDK.OnAccountDialogClose += () => ResumeGame();
```

Release **2.5.1** (README install pin + CHANGELOG updated).
